### PR TITLE
refactor: add UI base classes

### DIFF
--- a/ui/accounts/account_popup.py
+++ b/ui/accounts/account_popup.py
@@ -1,8 +1,9 @@
 import tkinter as tk
-from tkinter import messagebox, ttk # Import ttk
-from shared.structs import Address, Account, AccountType # Import AccountType
+from tkinter import messagebox, ttk  # Import ttk
+from shared.structs import Address, Account, AccountType  # Import AccountType
+from ui.base.popup_base import PopupBase
 
-class AccountDetailsPopup(tk.Toplevel):
+class AccountDetailsPopup(PopupBase):
     def __init__(self, master, logic, account_id=None):
         super().__init__(master)
         self.logic = logic
@@ -163,15 +164,7 @@ class AccountDetailsPopup(tk.Toplevel):
 
         self.destroy()
 
-    def _create_entry(self, label_text, row, initial_value=""):
-        label = tk.Label(self, text=label_text)
-        label.grid(row=row, column=0, padx=5, pady=5, sticky="e")
-        entry = tk.Entry(self, width=40)
-        entry.insert(0, initial_value if initial_value is not None else "")
-        entry.grid(row=row, column=1, padx=5, pady=5)
-        return entry
-
-class AddressPopup(tk.Toplevel):
+class AddressPopup(PopupBase):
     def __init__(self, master, address=None):
         super().__init__(master)
         self.address = address if address else Address()
@@ -192,14 +185,6 @@ class AddressPopup(tk.Toplevel):
         self.primary_check = tk.Checkbutton(self, text="Primary", variable=self.primary_var)
         self.primary_check.grid(row=6, column=0, columnspan=2)
         tk.Button(self, text="Save", command=self.save).grid(row=7, column=0, columnspan=2)
-
-    def _create_entry(self, label_text, row, initial_value=""):
-        label = tk.Label(self, text=label_text)
-        label.grid(row=row, column=0, padx=5, pady=5, sticky="e")
-        entry = tk.Entry(self, width=40)
-        entry.insert(0, initial_value if initial_value is not None else "")
-        entry.grid(row=row, column=1, padx=5, pady=5)
-        return entry
 
     def save(self):
         self.address.street = self.street_entry.get()

--- a/ui/accounts/account_tab.py
+++ b/ui/accounts/account_tab.py
@@ -1,11 +1,13 @@
 import tkinter as tk
 from tkinter import messagebox, ttk
-from ui.accounts.account_popup import AccountDetailsPopup # Renamed file, relative import
-from shared.structs import Account, AccountType # Moved to shared package, Import AccountType
+from ui.accounts.account_popup import AccountDetailsPopup
+from shared.structs import Account, AccountType
+from ui.base.tab_base import TabBase
 
-class AccountTab:
+
+class AccountTab(TabBase):
     def __init__(self, master, logic):
-        self.frame = tk.Frame(master)
+        super().__init__(master)
         self.logic = logic
         self.selected_account_id = None  # Initialize selected_account_id as None
 
@@ -14,34 +16,33 @@ class AccountTab:
         self.load_accounts()
 
         # Bind the FocusIn event to reload the listbox each time the tab gains focus
-        self.frame.bind("<FocusIn>", lambda event: self.load_accounts())
+        self.bind("<FocusIn>", lambda event: self.load_accounts())
 
     def setup_account_tab(self):
         """Setup the Account Administration tab with account fields and account list."""
-        tk.Label(self.frame, text="Accounts").grid(row=0, column=0, padx=5, pady=5, sticky="w")
+        tk.Label(self, text="Accounts").grid(row=0, column=0, padx=5, pady=5, sticky="w")
 
         button_width = 20
 
         # Add account buttons
         self.add_account_button = tk.Button(
-            self.frame, text="Add New Account",
-            command=lambda: self.create_new_account(), width=button_width)
+            self, text="Add New Account",
+            command=self.create_new_account, width=button_width)
         self.add_account_button.grid(row=3, column=0, padx=5, pady=5)
 
         self.edit_account_button = tk.Button(
-            self.frame, text="Edit Account",
+            self, text="Edit Account",
             command=self.edit_existing_account, width=button_width)
         self.edit_account_button.grid(row=3, column=1, padx=5, pady=5)
 
         self.remove_account_button = tk.Button(
-            self.frame, text="Remove Account",
+            self, text="Remove Account",
             command=self.remove_account, width=button_width)
         self.remove_account_button.grid(row=3, column=2, padx=5, pady=5)
 
-
         # Treeview for displaying accounts
-        self.tree = ttk.Treeview(self.frame, columns=("id", "name", "phone", "description", "account_type"), show="headings")
-        self.tree.column("id", width=0, stretch=False) # Hidden ID column
+        self.tree = ttk.Treeview(self, columns=("id", "name", "phone", "description", "account_type"), show="headings")
+        self.tree.column("id", width=0, stretch=False)  # Hidden ID column
         self.tree.heading("name", text="Account Name", command=lambda: self.sort_column("name", False))
         self.tree.heading("phone", text="Phone", command=lambda: self.sort_column("phone", False))
         self.tree.heading("description", text="Description", command=lambda: self.sort_column("description", False))
@@ -50,62 +51,43 @@ class AccountTab:
         self.tree.column("phone", width=100)
         self.tree.column("description", width=150)
         self.tree.column("account_type", width=100)
-        self.tree.grid(row=7, column=0, columnspan=4, padx=5, pady=5, sticky="nsew") # Increased columnspan
+        self.tree.grid(row=7, column=0, columnspan=4, padx=5, pady=5, sticky="nsew")  # Increased columnspan
         self.tree.bind("<<TreeviewSelect>>", self.select_account)
 
         # Configure the grid row and column containing the tree to expand
-        self.frame.grid_rowconfigure(7, weight=1)
-        self.frame.grid_columnconfigure(0, weight=1)
-
-
-    def sort_column(self, col, reverse):
-        """Sort the Treeview column when clicked."""
-        try:
-            data = [(self.tree.set(k, col).lower(), k) for k in self.tree.get_children("")] # Convert to lowercase for case-insensitive sort
-        except tk.TclError: # Happens if column has non-string sortable data, less likely with our current data
-            data = [(self.tree.set(k, col), k) for k in self.tree.get_children("")]
-
-        data.sort(reverse=reverse)
-
-        # Rearrange items in sorted positions
-        for index, (val, k) in enumerate(data):
-            self.tree.move(k, "", index)
-
-        # Toggle sort direction for next time
-        self.tree.heading(col, command=lambda: self.sort_column(col, not reverse))
+        self.grid_rowconfigure(7, weight=1)
+        self.grid_columnconfigure(0, weight=1)
 
     def remove_account(self):
         if not self.selected_account_id:
-                messagebox.showwarning("No Selection", "Please select an account to delete.")
-                return
+            messagebox.showwarning("No Selection", "Please select an account to delete.")
+            return
         # Add confirmation dialog
         confirm = messagebox.askyesno("Confirm Delete", f"Are you sure you want to delete account ID: {self.selected_account_id}?")
         if confirm:
             try:
                 self.logic.delete_account(self.selected_account_id)
                 messagebox.showinfo("Success", "Account deleted successfully.")
-                self.load_accounts() # Refresh list
-            except Exception as e: # Catch potential errors from logic/db layer
+                self.load_accounts()  # Refresh list
+            except Exception as e:  # Catch potential errors from logic/db layer
                 messagebox.showerror("Error", f"Failed to delete account: {e}")
         else:
             messagebox.showinfo("Cancelled", "Account deletion cancelled.")
-
 
     def edit_existing_account(self):
         if not self.selected_account_id:
             messagebox.showwarning("No Selection", "Please select an account to edit.")
             return
         # Pass self.load_accounts as a callback to refresh after edit
-        popup = AccountDetailsPopup(self.frame, self.logic, self.selected_account_id)
-        self.frame.wait_window(popup) # Wait for popup to close
-        self.load_accounts() # Then reload
+        popup = AccountDetailsPopup(self, self.logic, self.selected_account_id)
+        self.wait_window(popup)  # Wait for popup to close
+        self.load_accounts()  # Then reload
 
     def create_new_account(self):
         # Pass self.load_accounts as a callback to refresh after add
-        popup = AccountDetailsPopup(self.frame, self.logic, None)
-        self.frame.wait_window(popup) # Wait for popup to close
-        self.load_accounts() # Then reload
-
+        popup = AccountDetailsPopup(self, self.logic, None)
+        self.wait_window(popup)  # Wait for popup to close
+        self.load_accounts()  # Then reload
 
     def load_accounts(self):
         """Load accounts into the Tree"""
@@ -116,7 +98,6 @@ class AccountTab:
 
         # Retrieve all accounts - logic.get_all_accounts() should now return Account objects
         accounts_obj_list = self.logic.get_all_accounts()
-
 
         for account_obj in accounts_obj_list:
             account_type_display = account_obj.account_type.value if account_obj.account_type else "N/A"
@@ -129,14 +110,11 @@ class AccountTab:
                 account_type_display,
             ))
 
-
     def select_account(self, event=None):
         """Retrieve the Account_ID of the selected account."""
         selected_item = self.tree.selection()
         if selected_item:
             # First value in 'values' is the account_id
             self.selected_account_id = self.tree.item(selected_item[0], 'values')[0]
-            # print(f"Selected Account_ID: {self.selected_account_id}") # For debugging
         else:
             self.selected_account_id = None
-            # print("No account selected.") # For debugging

--- a/ui/base/__init__.py
+++ b/ui/base/__init__.py
@@ -1,0 +1,4 @@
+from .popup_base import PopupBase
+from .tab_base import TabBase
+
+__all__ = ["PopupBase", "TabBase"]

--- a/ui/base/popup_base.py
+++ b/ui/base/popup_base.py
@@ -1,0 +1,27 @@
+import tkinter as tk
+from tkinter import messagebox
+
+class PopupBase(tk.Toplevel):
+    """Base class for popup dialogs providing common Tkinter helpers."""
+
+    def __init__(self, master, *args, title: str | None = None, **kwargs):
+        super().__init__(master, *args, **kwargs)
+        if title:
+            self.title(title)
+
+    def _create_entry(self, label_text: str, row: int, initial_value: str | float | None = "", width: int = 40):
+        """Create a labeled entry widget and return the entry."""
+        label = tk.Label(self, text=label_text)
+        label.grid(row=row, column=0, padx=5, pady=5, sticky="e")
+        entry = tk.Entry(self, width=width)
+        if initial_value is not None:
+            entry.insert(0, initial_value)
+        entry.grid(row=row, column=1, padx=5, pady=5)
+        return entry
+
+    def validate_not_empty(self, value: str, field_name: str) -> bool:
+        """Validate that ``value`` is not empty. Return True if valid."""
+        if not value.strip():
+            messagebox.showerror("Validation Error", f"{field_name} cannot be empty.")
+            return False
+        return True

--- a/ui/base/tab_base.py
+++ b/ui/base/tab_base.py
@@ -1,0 +1,34 @@
+import tkinter as tk
+import datetime
+
+class TabBase(tk.Frame):
+    """Base class for tab frames with shared helpers."""
+
+    def __init__(self, master, *args, **kwargs):
+        super().__init__(master, *args, **kwargs)
+
+    def sort_column(self, col: str, reverse: bool):
+        """Generic Treeview column sorter.
+
+        Attempts to sort numerically, handling currency strings and ISO dates
+        before falling back to a case-insensitive string comparison.
+        Assumes a ``ttk.Treeview`` widget assigned to ``self.tree``.
+        """
+        data = []
+        for k in self.tree.get_children(""):
+            value = self.tree.set(k, col)
+            sort_val = value
+            if isinstance(value, str):
+                try:
+                    sort_val = float(value.lstrip("$"))
+                except ValueError:
+                    try:
+                        sort_val = datetime.datetime.strptime(value, "%Y-%m-%d")
+                    except ValueError:
+                        sort_val = value.lower()
+            data.append((sort_val, k))
+
+        data.sort(key=lambda item: item[0], reverse=reverse)
+        for index, (_, k) in enumerate(data):
+            self.tree.move(k, "", index)
+        self.tree.heading(col, command=lambda: self.sort_column(col, not reverse))

--- a/ui/contacts/contact_popup.py
+++ b/ui/contacts/contact_popup.py
@@ -1,11 +1,12 @@
 import tkinter as tk
 from tkinter import ttk, messagebox
 from shared.structs import Contact  # Import Contact
-from core.address_book_logic import AddressBookLogic # Assuming this is how logic is passed
+from core.address_book_logic import AddressBookLogic  # Assuming this is how logic is passed
+from ui.base.popup_base import PopupBase
 
 NO_ACCOUNT_LABEL = "<No Account>"
 
-class ContactDetailsPopup(tk.Toplevel):
+class ContactDetailsPopup(PopupBase):
     def __init__(self, master_window, contact_tab_controller, logic: AddressBookLogic, contact_id=None):
         self.contact_tab_controller = contact_tab_controller
         super().__init__(master_window)
@@ -116,13 +117,11 @@ class ContactDetailsPopup(tk.Toplevel):
 
     def save_contact(self):
         name = self.name_entry.get().strip()
+        if not self.validate_not_empty(name, "Name"):
+            return
         phone = self.phone_entry.get().strip()
         email = self.email_entry.get().strip()
         role = self.role_entry.get().strip()
-
-        if not name:
-            messagebox.showerror("Validation Error", "Name cannot be empty.")
-            return
 
         selected_account_display_name = self.account_combobox.get() # Get current value from combobox
 

--- a/ui/contacts/contact_tab.py
+++ b/ui/contacts/contact_tab.py
@@ -1,27 +1,25 @@
 import tkinter as tk
 from tkinter import messagebox, ttk
-from ui.contacts.contact_popup import ContactDetailsPopup # Renamed file, relative import
-# Import Contact if needed for type hinting, though logic layer currently returns Contact objects
-from shared.structs import Contact # Moved to shared package
+from ui.contacts.contact_popup import ContactDetailsPopup
+from shared.structs import Contact
+from ui.base.tab_base import TabBase
 
-class ContactTab:
+
+class ContactTab(TabBase):
     def __init__(self, master, logic):
-        self.frame = tk.Frame(master)
+        super().__init__(master)
         self.logic = logic
         self.selected_contact_id = None
 
         self.setup_contact_tab()
         self.load_contacts()
-
-        # Consider binding to a more appropriate event if FocusIn causes too frequent reloads
-        # Or implement a specific refresh button if preferred.
-        self.frame.bind("<FocusIn>", self.load_contacts)
+        self.bind("<FocusIn>", self.load_contacts)
 
     def setup_contact_tab(self):
-        tk.Label(self.frame, text="Contact Management").grid(row=0, column=0, columnspan=3, padx=5, pady=5, sticky="w")
+        tk.Label(self, text="Contact Management").grid(row=0, column=0, columnspan=3, padx=5, pady=5, sticky="w")
 
         button_width = 20
-        button_frame = tk.Frame(self.frame)
+        button_frame = tk.Frame(self)
         button_frame.grid(row=1, column=0, columnspan=3, pady=5)
 
         self.add_contact_button = tk.Button(
@@ -39,11 +37,9 @@ class ContactTab:
             command=self.remove_contact, width=button_width)
         self.remove_contact_button.pack(side=tk.LEFT, padx=5)
 
-        # Treeview for displaying contacts
-        # Columns: "id" (hidden), "name", "phone", "email", "role", "account_name"
-        self.tree = ttk.Treeview(self.frame, columns=("id", "name", "phone", "email", "role", "account_name"), show="headings")
+        self.tree = ttk.Treeview(self, columns=("id", "name", "phone", "email", "role", "account_name"), show="headings")
 
-        self.tree.column("id", width=0, stretch=False) # Hidden ID column
+        self.tree.column("id", width=0, stretch=False)  # Hidden ID column
         self.tree.heading("name", text="Contact Name", command=lambda: self.sort_column("name", False))
         self.tree.heading("phone", text="Phone", command=lambda: self.sort_column("phone", False))
         self.tree.heading("email", text="Email", command=lambda: self.sort_column("email", False))
@@ -57,21 +53,10 @@ class ContactTab:
         self.tree.column("account_name", width=120, anchor=tk.W)
 
         self.tree.grid(row=2, column=0, columnspan=3, padx=5, pady=5, sticky="nsew")
-        self.frame.grid_rowconfigure(2, weight=1)
-        self.frame.grid_columnconfigure(0, weight=1)
+        self.grid_rowconfigure(2, weight=1)
+        self.grid_columnconfigure(0, weight=1)
 
         self.tree.bind("<<TreeviewSelect>>", self.on_contact_select)
-
-    def sort_column(self, col, reverse):
-        data = [(self.tree.set(k, col), k) for k in self.tree.get_children("")]
-        try: # Attempt numeric sort for relevant columns if possible, else string sort
-            data.sort(key=lambda item: float(item[0]), reverse=reverse)
-        except ValueError:
-            data.sort(key=lambda item: str(item[0]).lower(), reverse=reverse)
-
-        for index, (val, k) in enumerate(data):
-            self.tree.move(k, "", index)
-        self.tree.heading(col, command=lambda: self.sort_column(col, not reverse))
 
     def on_contact_select(self, event=None):
         selected_items = self.tree.selection()
@@ -86,54 +71,43 @@ class ContactTab:
             messagebox.showwarning("No Selection", "Please select a contact to delete.")
             return
 
-        # Step 1: Capture the selected ID into a new local variable immediately.
         id_to_process = self.selected_contact_id
-
-        # Step 2: Use this captured ID in the confirmation dialog.
         confirm = messagebox.askyesno(
             "Confirm Delete",
-            f"Are you sure you want to delete the selected contact (ID: {id_to_process})?"
+            f"Are you sure you want to delete the selected contact (ID: {id_to_process})?",
         )
 
         if confirm:
             try:
-                # Step 3: Use the captured ID for the deletion logic.
                 self.logic.delete_contact(id_to_process)
-
-                # Step 4: Refresh the contact list.
                 self.load_contacts()
-
-                # Step 5: Use the captured ID in the success message.
                 messagebox.showinfo(
                     "Success",
-                    f"Contact (ID: {id_to_process}) deleted successfully."
+                    f"Contact (ID: {id_to_process}) deleted successfully.",
                 )
             except Exception as e:
                 messagebox.showerror("Error", f"Failed to delete contact: {e}")
-
-            # Step 6: Reset selection (safeguard, as load_contacts should also do it).
             self.selected_contact_id = None
 
     def edit_existing_contact(self):
         if not self.selected_contact_id:
             messagebox.showwarning("No Selection", "Please select a contact to edit.")
             return
-        # The ContactDetailsPopup now handles fetching the contact details by ID
-        popup = ContactDetailsPopup(self.frame.master, self, self.logic, contact_id=self.selected_contact_id)
-        self.frame.master.wait_window(popup) # Wait for popup to close
-        self.load_contacts() # Refresh list after potential edit
-
-    def create_new_contact(self):
-        popup = ContactDetailsPopup(self.frame.master, self, self.logic, contact_id=None)
-        self.frame.master.wait_window(popup)
+        popup = ContactDetailsPopup(self.master, self, self.logic, contact_id=self.selected_contact_id)
+        self.master.wait_window(popup)
         self.load_contacts()
 
-    def load_contacts(self, event=None): # event parameter for binding
+    def create_new_contact(self):
+        popup = ContactDetailsPopup(self.master, self, self.logic, contact_id=None)
+        self.master.wait_window(popup)
+        self.load_contacts()
+
+    def load_contacts(self, event=None):  # event parameter for binding
         self.tree.delete(*self.tree.get_children())
-        self.selected_contact_id = None # Reset selection
+        self.selected_contact_id = None  # Reset selection
 
         try:
-            contacts = self.logic.get_all_contacts() # Returns list of Contact objects
+            contacts = self.logic.get_all_contacts()  # Returns list of Contact objects
             for contact in contacts:
                 account_name_display = "N/A"
                 if contact.account_id:
@@ -142,7 +116,7 @@ class ContactTab:
                         account_name_display = account.name
 
                 self.tree.insert("", "end", iid=contact.contact_id, values=(
-                    contact.contact_id, # Stored in hidden "id" column, accessed by iid
+                    contact.contact_id,  # Stored in hidden "id" column, accessed by iid
                     contact.name,
                     contact.phone,
                     contact.email,
@@ -151,59 +125,7 @@ class ContactTab:
                 ))
         except Exception as e:
             messagebox.showerror("Load Error", f"Failed to load contacts: {e}")
-            print(f"Error in load_contacts: {e}") # For console debugging
+            print(f"Error in load_contacts: {e}")  # For console debugging
 
-    def refresh_contacts_list(self): # Added method for popup to call
+    def refresh_contacts_list(self):  # Added method for popup to call
         self.load_contacts()
-
-# Example of how to integrate into a main application (for testing)
-if __name__ == '__main__':
-    root = tk.Tk()
-    root.title("Contact Management Tab Test")
-
-    # Mock Logic class for testing
-    class MockLogic:
-        def get_all_contacts(self):
-            print("MockLogic: get_all_contacts called")
-            # Simulate Contact objects (or dicts if logic layer changes)
-            # from src.structs import Contact # Already imported above or ensure it's available
-            return [
-                Contact(contact_id=1, name="John Doe", phone="123-456-7890", email="john.doe@example.com", account_id=101),
-                Contact(contact_id=2, name="Jane Smith", phone="987-654-3210", email="jane.smith@example.com", account_id=102),
-                Contact(contact_id=3, name="Alice Brown", phone="555-555-5555", email="alice.brown@example.com", account_id=101)
-            ]
-
-        def get_account_details(self, account_id):
-            print(f"MockLogic: get_account_details called for {account_id}")
-            from shared.structs import Account # For mock objects
-            if account_id == 101:
-                return Account(account_id=101, name="Alpha Corp")
-            if account_id == 102:
-                return Account(account_id=102, name="Beta LLC")
-            return None
-
-        def delete_contact(self, contact_id):
-            print(f"MockLogic: delete_contact called for {contact_id}")
-            messagebox.showinfo("Mock Delete", f"Contact {contact_id} would be deleted.")
-            return True # Simulate success
-
-        def get_contact_details(self, contact_id): # Needed by ContactDetailsPopup
-            print(f"MockLogic: get_contact_details called for {contact_id}")
-            # from src.structs import Contact # Already imported above or ensure it's available
-            if contact_id == 1:
-                 return Contact(contact_id=1, name="John Doe", phone="123-456-7890", email="john.doe@example.com", account_id=101)
-            return None
-
-        def save_contact(self, contact): # Needed by ContactDetailsPopup
-            print(f"MockLogic: save_contact called for {contact.name if contact else 'None'}")
-
-        def get_all_accounts(self): # Needed by ContactDetailsPopup
-            print("MockLogic: get_all_accounts called")
-            return [(101, "Alpha Corp"), (102, "Beta LLC")]
-
-
-    mock_logic = MockLogic()
-    app_tab = ContactTab(root, mock_logic)
-    app_tab.frame.pack(expand=True, fill=tk.BOTH)
-    root.geometry("700x400")
-    root.mainloop()

--- a/ui/main_view.py
+++ b/ui/main_view.py
@@ -55,8 +55,8 @@ class AddressBookView:
 
 
         # Add frames from tabs to Notebook
-        self.notebook.add(self.account_tab.frame, text="Account Administration")
-        self.notebook.add(self.contact_tab.frame, text="Contact Information")
+        self.notebook.add(self.account_tab, text="Account Administration")
+        self.notebook.add(self.contact_tab, text="Contact Information")
         self.notebook.add(self.interaction_log_tab, text="Interaction Log")
         self.notebook.add(self.task_tab, text="Tasks")
         self.notebook.add(self.product_tab.frame, text="Products")

--- a/ui/pricing/pricing_rule_popup.py
+++ b/ui/pricing/pricing_rule_popup.py
@@ -1,8 +1,9 @@
 import tkinter as tk
 from tkinter import messagebox
 from shared.structs import PricingRule
+from ui.base.popup_base import PopupBase
 
-class PricingRulePopup(tk.Toplevel):
+class PricingRulePopup(PopupBase):
     def __init__(self, master, logic, rule_id=None):
         super().__init__(master)
         self.logic = logic
@@ -22,23 +23,12 @@ class PricingRulePopup(tk.Toplevel):
         save_button = tk.Button(self, text="Save", command=self.save_rule)
         save_button.grid(row=3, column=0, columnspan=2, pady=10)
 
-    def _create_entry(self, label_text, row, initial_value=""):
-        label = tk.Label(self, text=label_text)
-        label.grid(row=row, column=0, padx=5, pady=5, sticky="e")
-        entry = tk.Entry(self, width=40)
-        if initial_value is not None:
-            entry.insert(0, initial_value)
-        entry.grid(row=row, column=1, padx=5, pady=5)
-        return entry
-
     def save_rule(self):
         rule_name = self.name_entry.get()
+        if not self.validate_not_empty(rule_name, "Rule name"):
+            return
         markup_str = self.markup_entry.get()
         fixed_price_str = self.fixed_price_entry.get()
-
-        if not rule_name:
-            messagebox.showerror("Error", "Rule name cannot be empty.")
-            return
 
         markup = None
         if markup_str:


### PR DESCRIPTION
## Summary
- centralize popup helpers and validation in `PopupBase`
- provide generic tree sorting through `TabBase`
- refactor account and contact UIs to inherit shared base implementations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688c37541bf483319b2d9f67356bab3b