### PR TITLE
refactor: centralize address management

### DIFF
--- a/core/address_service.py
+++ b/core/address_service.py
@@ -1,0 +1,67 @@
+from typing import Optional
+from shared.structs import Address, Account
+from shared.utils import ensure_single_primary
+
+
+class AddressService:
+    """Service for address validation and persistence."""
+
+    def __init__(self, db_handler):
+        self.db = db_handler
+
+    # Basic CRUD wrappers
+    def add_address(self, street, city, state, zip_code, country):
+        """Add a new address and return its ID."""
+        return self.db.add_address(street, city, state, zip_code, country)
+
+    def update_address(self, address_id, street, city, state, zip_code, country):
+        """Update an existing address."""
+        self.db.update_address(address_id, street, city, state, zip_code, country)
+
+    def get_address_obj(self, address_id) -> Optional[Address]:
+        """Retrieve an Address object for the given ID."""
+        data = self.db.get_address(address_id)
+        if data:
+            return Address(
+                address_id=address_id,
+                street=data[0],
+                city=data[1],
+                state=data[2],
+                zip_code=data[3],
+                country=data[4],
+            )
+        return None
+
+    # Higher level coordination
+    def save_account_addresses(self, account: Account):
+        """Persist all addresses for an account after enforcing validation rules."""
+        self.db.cursor.execute(
+            "DELETE FROM account_addresses WHERE account_id = ?", (account.account_id,)
+        )
+
+        ensure_single_primary(account.addresses)
+
+        for address in account.addresses:
+            if address.address_id:
+                self.update_address(
+                    address.address_id,
+                    address.street,
+                    address.city,
+                    address.state,
+                    address.zip_code,
+                    address.country,
+                )
+                self.db.add_account_address(
+                    account.account_id, address.address_id, address.address_type, address.is_primary
+                )
+            else:
+                address_id = self.add_address(
+                    address.street,
+                    address.city,
+                    address.state,
+                    address.zip_code,
+                    address.country,
+                )
+                self.db.add_account_address(
+                    account.account_id, address_id, address.address_type, address.is_primary
+                )

--- a/shared/utils.py
+++ b/shared/utils.py
@@ -4,6 +4,25 @@ import unicodedata
 # This file will contain common utility functions, constants, enums, etc.
 # Placeholder for now.
 
+
+def ensure_single_primary(addresses):
+    """Ensure only one address per type remains marked as primary.
+
+    The last address in the list marked as primary for a given type
+    (e.g., "Billing" or "Shipping") is kept as primary and earlier
+    ones are demoted. The list is modified in place.
+    """
+    seen = {}
+    for address in reversed(addresses):
+        if getattr(address, "is_primary", False):
+            addr_type = getattr(address, "address_type", None)
+            if addr_type is None:
+                continue
+            if seen.get(addr_type):
+                address.is_primary = False
+            else:
+                seen[addr_type] = True
+
 def sanitize_filename(filename: str) -> str:
     """
     Sanitizes a string to be a valid filename.

--- a/tests/unit/test_address_book_logic.py
+++ b/tests/unit/test_address_book_logic.py
@@ -3,6 +3,7 @@ import os
 import sqlite3 # Import for PRAGMA
 from core.database import DatabaseHandler
 from core.address_book_logic import AddressBookLogic
+from core.address_service import AddressService
 from shared.structs import Product, AccountType, Account # Added AccountType for product tests if needed
 
 class TestAddressBookLogic(unittest.TestCase):
@@ -11,7 +12,8 @@ class TestAddressBookLogic(unittest.TestCase):
         # Create a fresh in-memory DB and initialize schema for EACH test method
         self.db_handler = DatabaseHandler(db_name=':memory:')
         # initialize_database is already called in DatabaseHandler's __init__
-        self.logic = AddressBookLogic(self.db_handler)
+        self.address_service = AddressService(self.db_handler)
+        self.logic = AddressBookLogic(self.db_handler, self.address_service)
 
         # Diagnostic: Print products table schema
         print("\n--- test_address_book_logic.py setUp: Products table schema ---")
@@ -161,7 +163,7 @@ class TestAddressBookLogic(unittest.TestCase):
         billing_address2.is_primary = True
         account.addresses.append(billing_address1)
         account.addresses.append(billing_address2)
-        self.logic.save_account_addresses(account)
+        self.address_service.save_account_addresses(account)
 
         # Verify that only one is primary
         addresses = self.db_handler.get_account_addresses(account.account_id)
@@ -177,7 +179,7 @@ class TestAddressBookLogic(unittest.TestCase):
         shipping_address2.is_primary = True
         account.addresses.append(shipping_address1)
         account.addresses.append(shipping_address2)
-        self.logic.save_account_addresses(account)
+        self.address_service.save_account_addresses(account)
 
         # Verify that only one is primary
         addresses = self.db_handler.get_account_addresses(account.account_id)

--- a/ui/company_info_tab.py
+++ b/ui/company_info_tab.py
@@ -2,6 +2,7 @@ import tkinter as tk
 from tkinter import ttk, messagebox
 from shared.structs import CompanyInformation, Address
 from core.database import DatabaseHandler # Required for type hinting if logic layer is not fully fleshed out yet.
+from shared.utils import ensure_single_primary
 
 class CompanyInfoTab:
     def __init__(self, master, db_handler: DatabaseHandler):
@@ -140,22 +141,7 @@ class CompanyInfoTab:
         self.company_info.phone = self.phone_entry.get()
 
         # Enforce single primary address
-        primary_billing_address_id = None
-        primary_shipping_address_id = None
-
-        # Find the last primary address of each type
-        for address in self.company_info.addresses:
-            if address.is_primary:
-                if address.address_type == 'Billing':
-                    primary_billing_address_id = address.address_id
-                elif address.address_type == 'Shipping':
-                    primary_shipping_address_id = address.address_id
-
-        # Update the addresses
-        for address in self.company_info.addresses:
-            is_primary = (address.address_type == 'Billing' and address.address_id == primary_billing_address_id) or \
-                         (address.address_type == 'Shipping' and address.address_id == primary_shipping_address_id)
-            address.is_primary = is_primary
+        ensure_single_primary(self.company_info.addresses)
 
         # Clear existing addresses and add the new ones
         self.db_handler.cursor.execute("DELETE FROM company_addresses WHERE company_id = ?", (self.company_info.company_id,))


### PR DESCRIPTION
## Summary
- Extracted address CRUD and validation to new `AddressService`
- Delegated account address persistence from `AddressBookLogic` to `AddressService`
- Added reusable `ensure_single_primary` helper and applied it across logic and UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c373db53483319f9e4059eaa24f84