### PR TITLE
refactor: extract address service for primary validation

### DIFF
--- a/core/address_service.py
+++ b/core/address_service.py
@@ -1,0 +1,85 @@
+from shared.structs import Address
+from core.repositories import AddressRepository, AccountRepository
+
+
+class AddressService:
+    """Service layer responsible for address validation and persistence."""
+
+    def __init__(self, address_repo: AddressRepository, account_repo: AccountRepository):
+        self.address_repo = address_repo
+        self.account_repo = account_repo
+
+    @staticmethod
+    def enforce_single_primary(addresses):
+        """Ensure only one primary address exists for each type."""
+        primary_billing_found = False
+        primary_shipping_found = False
+        for address in reversed(addresses):
+            if getattr(address, "is_primary", False):
+                if address.address_type == "Billing":
+                    if primary_billing_found:
+                        address.is_primary = False
+                    else:
+                        primary_billing_found = True
+                elif address.address_type == "Shipping":
+                    if primary_shipping_found:
+                        address.is_primary = False
+                    else:
+                        primary_shipping_found = True
+
+    def add_address(self, street, city, state, zip_code, country):
+        """Add a new address and return its ID."""
+        return self.address_repo.add_address(street, city, state, zip_code, country)
+
+    def update_address(self, address_id, street, city, state, zip_code, country):
+        """Update an existing address."""
+        self.address_repo.update_address(address_id, street, city, state, zip_code, country)
+
+    def get_address_obj(self, address_id):
+        """Retrieve an Address object by ID."""
+        data = self.address_repo.get_address(address_id)
+        if data:
+            return Address(
+                address_id=address_id,
+                street=data[0],
+                city=data[1],
+                state=data[2],
+                zip_code=data[3],
+                country=data[4],
+            )
+        return None
+
+    def save_account_addresses(self, account):
+        """Persist addresses for an account after enforcing primary constraints."""
+        self.account_repo.clear_account_addresses(account.account_id)
+        self.enforce_single_primary(account.addresses)
+        for address in account.addresses:
+            if address.address_id:
+                self.address_repo.update_address(
+                    address.address_id,
+                    address.street,
+                    address.city,
+                    address.state,
+                    address.zip_code,
+                    address.country,
+                )
+                self.account_repo.add_account_address(
+                    account.account_id,
+                    address.address_id,
+                    address.address_type,
+                    address.is_primary,
+                )
+            else:
+                address_id = self.address_repo.add_address(
+                    address.street,
+                    address.city,
+                    address.state,
+                    address.zip_code,
+                    address.country,
+                )
+                self.account_repo.add_account_address(
+                    account.account_id,
+                    address_id,
+                    address.address_type,
+                    address.is_primary,
+                )

--- a/ui/company_info_tab.py
+++ b/ui/company_info_tab.py
@@ -1,6 +1,7 @@
 import tkinter as tk
 from tkinter import ttk, messagebox
 from shared.structs import CompanyInformation, Address
+from core.address_service import AddressService
 from core.database import DatabaseHandler # Required for type hinting if logic layer is not fully fleshed out yet.
 
 class CompanyInfoTab:
@@ -139,23 +140,8 @@ class CompanyInfoTab:
         self.company_info.name = self.name_entry.get()
         self.company_info.phone = self.phone_entry.get()
 
-        # Enforce single primary address
-        primary_billing_address_id = None
-        primary_shipping_address_id = None
-
-        # Find the last primary address of each type
-        for address in self.company_info.addresses:
-            if address.is_primary:
-                if address.address_type == 'Billing':
-                    primary_billing_address_id = address.address_id
-                elif address.address_type == 'Shipping':
-                    primary_shipping_address_id = address.address_id
-
-        # Update the addresses
-        for address in self.company_info.addresses:
-            is_primary = (address.address_type == 'Billing' and address.address_id == primary_billing_address_id) or \
-                         (address.address_type == 'Shipping' and address.address_id == primary_shipping_address_id)
-            address.is_primary = is_primary
+        # Enforce single primary address using shared helper
+        AddressService.enforce_single_primary(self.company_info.addresses)
 
         # Clear existing addresses and add the new ones
         self.db_handler.cursor.execute("DELETE FROM company_addresses WHERE company_id = ?", (self.company_info.company_id,))


### PR DESCRIPTION
## Summary
- move address CRUD and primary validation into dedicated `AddressService`
- delegate address persistence from `AddressBookLogic` to the new service
- reuse validation helper in company info UI to enforce single primary address

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688cac3a71c08331b166aed4cae0be07