### PR TITLE
Introduce company service layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 This project is a lightweight CRM system that manages accounts, contacts, products, purchase documents, sales documents, and tasks.
 
+## Architecture
+
+The codebase follows a repository and service pattern to separate concerns:
+
+- **Repositories** encapsulate data-access logic and interact with the database. Each repository implements an interface that declares the supported operations.
+- **Services** contain business rules and coordinate repository calls. Controllers/UI components depend on services rather than accessing the database directly.
+
+For example, `CompanyService` coordinates address validation and persistence through `CompanyRepository` and `AddressService`.
+
 ## Running Tests
 
 Install dependencies and run the test suite from the repository root:

--- a/core/company_repository.py
+++ b/core/company_repository.py
@@ -1,0 +1,56 @@
+from abc import ABC, abstractmethod
+from core.database import DatabaseHandler
+
+
+class ICompanyRepository(ABC):
+    """Interface for company-related database operations."""
+
+    @abstractmethod
+    def get_company_information(self) -> dict | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def update_company_information(self, company_id: int, name: str, phone: str) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def add_company_information(self, name: str, phone: str) -> int:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_company_addresses(self, company_id: int) -> list[dict]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def add_company_address(self, company_id: int, address_id: int, address_type: str, is_primary: bool) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def clear_company_addresses(self, company_id: int) -> None:
+        raise NotImplementedError
+
+
+class CompanyRepository(ICompanyRepository):
+    """Concrete repository that uses DatabaseHandler for persistence."""
+
+    def __init__(self, db: DatabaseHandler):
+        self.db = db
+
+    def get_company_information(self) -> dict | None:
+        return self.db.get_company_information()
+
+    def update_company_information(self, company_id: int, name: str, phone: str) -> None:
+        self.db.update_company_information(company_id, name, phone)
+
+    def add_company_information(self, name: str, phone: str) -> int:
+        return self.db.add_company_information(name, phone)
+
+    def get_company_addresses(self, company_id: int) -> list[dict]:
+        return self.db.get_company_addresses(company_id)
+
+    def add_company_address(self, company_id: int, address_id: int, address_type: str, is_primary: bool) -> None:
+        self.db.add_company_address(company_id, address_id, address_type, is_primary)
+
+    def clear_company_addresses(self, company_id: int) -> None:
+        self.db.cursor.execute("DELETE FROM company_addresses WHERE company_id = ?", (company_id,))
+        self.db.conn.commit()

--- a/core/company_service.py
+++ b/core/company_service.py
@@ -1,0 +1,67 @@
+from shared.structs import CompanyInformation, Address
+from core.address_service import AddressService
+from .company_repository import ICompanyRepository
+
+
+class CompanyService:
+    """Service layer for managing company information and addresses."""
+
+    def __init__(self, repo: ICompanyRepository, address_service: AddressService):
+        self.repo = repo
+        self.address_service = address_service
+
+    def load_company_information(self) -> CompanyInformation:
+        """Retrieve company information, creating a default if none exists."""
+        data = self.repo.get_company_information()
+        if not data:
+            company_id = self.repo.add_company_information("My Company", "")
+            return CompanyInformation(company_id=company_id, name="My Company", phone="", addresses=[])
+
+        company = CompanyInformation(
+            company_id=data.get("company_id"),
+            name=data.get("name", ""),
+            phone=data.get("phone", ""),
+            addresses=[],
+        )
+        addresses_data = self.repo.get_company_addresses(company.company_id)
+        for addr_data in addresses_data:
+            address = Address(
+                address_id=addr_data["address_id"],
+                street=addr_data["street"],
+                city=addr_data["city"],
+                state=addr_data["state"],
+                zip_code=addr_data["zip"],
+                country=addr_data["country"],
+            )
+            address.address_type = addr_data["address_type"]
+            address.is_primary = addr_data["is_primary"]
+            company.addresses.append(address)
+        return company
+
+    def save_company_information(self, company: CompanyInformation) -> None:
+        """Persist updated company information and its addresses."""
+        self.address_service.enforce_single_primary(company.addresses)
+        self.repo.clear_company_addresses(company.company_id)
+        for address in company.addresses:
+            if address.address_id:
+                self.address_service.update_address(
+                    address.address_id,
+                    address.street,
+                    address.city,
+                    address.state,
+                    address.zip_code,
+                    address.country,
+                )
+                addr_id = address.address_id
+            else:
+                addr_id = self.address_service.add_address(
+                    address.street,
+                    address.city,
+                    address.state,
+                    address.zip_code,
+                    address.country,
+                )
+            self.repo.add_company_address(
+                company.company_id, addr_id, address.address_type, getattr(address, "is_primary", False)
+            )
+        self.repo.update_company_information(company.company_id, company.name, company.phone)

--- a/core/invoice_generator.py
+++ b/core/invoice_generator.py
@@ -83,8 +83,13 @@ def generate_invoice_pdf(sales_document_id: int, output_path: str = None):
         pdf.cell(col_width_half, line_height, company_name_for_header, 0, 1, "L")
 
         temp_x_offset = pdf.get_x()
-        pdf.multi_cell(col_width_half, line_height, "
-".join(company_shipping_address_pdf_lines), 0, "L")
+        pdf.multi_cell(
+            col_width_half,
+            line_height,
+            "\n".join(company_shipping_address_pdf_lines),
+            0,
+            "L",
+        )
         y_after_company_address = pdf.get_y()
         pdf.set_xy(temp_x_offset, y_after_company_address)
 
@@ -107,14 +112,15 @@ def generate_invoice_pdf(sales_document_id: int, output_path: str = None):
 
             if customer_address:
                 pdf.set_x(right_column_x)
+                address_lines = [
+                    customer_address.street or "",
+                    f"{customer_address.city or ''}, {customer_address.state or ''} {customer_address.zip_code or ''}",
+                    (customer_address.country or "").strip(),
+                ]
                 pdf.multi_cell(
                     col_width_half,
                     line_height,
-                    f"{customer_address.street or ''}
-"
-                    f"{customer_address.city or ''}, {customer_address.state or ''} {customer_address.zip_code or ''}
-"
-                    f"{customer_address.country or ''}".strip(),
+                    "\n".join(filter(None, address_lines)),
                     0,
                     "L",
                 )

--- a/core/invoice_generator.py
+++ b/core/invoice_generator.py
@@ -13,7 +13,12 @@ from core.sales_logic import SalesLogic
 from core.address_book_logic import AddressBookLogic
 from shared.structs import SalesDocument, SalesDocumentItem, Account, Address
 from shared.utils import sanitize_filename
-from core.pdf_generator import PDF
+from core.pdf_generator import PDF, get_company_pdf_context
+from core.company_repository import CompanyRepository
+from core.company_service import CompanyService
+from core.address_service import AddressService
+from core.repositories import AddressRepository, AccountRepository
+
 
 def generate_invoice_pdf(sales_document_id: int, output_path: str = None):
     db_handler = None
@@ -22,75 +27,23 @@ def generate_invoice_pdf(sales_document_id: int, output_path: str = None):
         sales_logic = SalesLogic(db_handler)
         address_book_logic = AddressBookLogic(db_handler)
 
+        address_repo = AddressRepository(db_handler)
+        account_repo = AccountRepository(db_handler)
+        address_service = AddressService(address_repo, account_repo)
+        company_repo = CompanyRepository(db_handler)
+        company_service = CompanyService(company_repo, address_service)
+
         doc: SalesDocument = sales_logic.get_sales_document_details(sales_document_id)
         if not doc:
             print(f"Error: Sales document with ID {sales_document_id} not found.")
             return
 
-        company_info_dict = db_handler.get_company_information()
-        company_name_for_header = "Your Company Name"
-        company_phone_pdf = ""
-        company_shipping_address_pdf_lines = ["Shipping address not found."]
-        company_billing_address_pdf_lines = ["Billing address not found."]
-
-        if company_info_dict:
-            company_name_for_header = company_info_dict.get('name', company_name_for_header)
-            company_phone_pdf = company_info_dict.get('phone', "")
-
-            company_shipping_address_id = company_info_dict.get('shipping_address_id')
-            if company_shipping_address_id:
-                addr_tuple = db_handler.get_address(company_shipping_address_id)
-                if addr_tuple:
-                    company_shipping_address_pdf_lines = [
-                        addr_tuple[0] or "",
-                        f"{addr_tuple[1] or ""}, {addr_tuple[2] or ""} {addr_tuple[3] or ""}",
-                        addr_tuple[4] or ""
-                    ]
-                    company_shipping_address_pdf_lines = [line for line in company_shipping_address_pdf_lines if line.strip()]
-                    if not company_shipping_address_pdf_lines:
-                         company_shipping_address_pdf_lines = ["Shipping address details missing."]
-                else:
-                    company_shipping_address_pdf_lines = ["Shipping address not found in DB (ID existed)."]
-            else:
-                temp_billing_id_for_shipping = company_info_dict.get('billing_address_id')
-                if temp_billing_id_for_shipping:
-                    company_shipping_address_pdf_lines = ["Shipping address not set, using Billing Address:"]
-                    addr_tuple = db_handler.get_address(temp_billing_id_for_shipping)
-                    if addr_tuple:
-                        shipping_fallback_lines = [
-                            addr_tuple[0] or "",
-                            f"{addr_tuple[1] or ""}, {addr_tuple[2] or ""} {addr_tuple[3] or ""}",
-                            addr_tuple[4] or ""
-                        ]
-                        shipping_fallback_lines = [line for line in shipping_fallback_lines if line.strip()]
-                        if not shipping_fallback_lines:
-                            company_shipping_address_pdf_lines = ["Shipping address not set, billing address details missing."]
-                        else:
-                            company_shipping_address_pdf_lines.extend(shipping_fallback_lines)
-                    else:
-                         company_shipping_address_pdf_lines = ["Shipping address not set, billing address not found."]
-                else:
-                    company_shipping_address_pdf_lines = ["No shipping or billing address configured for company."]
-
-            company_billing_address_id = company_info_dict.get('billing_address_id')
-            if company_billing_address_id:
-                addr_tuple = db_handler.get_address(company_billing_address_id)
-                if addr_tuple:
-                    company_billing_address_pdf_lines = [
-                        addr_tuple[0] or "",
-                        f"{addr_tuple[1] or ""}, {addr_tuple[2] or ""} {addr_tuple[3] or ""}",
-                        addr_tuple[4] or ""
-                    ]
-                    company_billing_address_pdf_lines = [line for line in company_billing_address_pdf_lines if line.strip()]
-                    if not company_billing_address_pdf_lines:
-                        company_billing_address_pdf_lines = ["Billing address details missing."]
-                else:
-                    company_billing_address_pdf_lines = ["Billing address not found in DB (ID existed)."]
-            else:
-                company_billing_address_pdf_lines = ["Billing address ID not configured for company."]
-        else:
-            company_shipping_address_pdf_lines = ["Company information not found in database."]
-            company_billing_address_pdf_lines = ["Company information not found in database."]
+        (
+            company_name_for_header,
+            company_phone_pdf,
+            company_shipping_address_pdf_lines,
+            company_billing_address_pdf_lines,
+        ) = get_company_pdf_context(company_service)
 
         customer: Account = None
         customer_address: Address = None
@@ -105,7 +58,7 @@ def generate_invoice_pdf(sales_document_id: int, output_path: str = None):
             document_number=doc.document_number,
             company_name=company_name_for_header,
             company_billing_address_lines=company_billing_address_pdf_lines,
-            document_type="Invoice"
+            document_type="Invoice",
         )
         pdf.alias_nb_pages()
         pdf.add_page()
@@ -130,7 +83,8 @@ def generate_invoice_pdf(sales_document_id: int, output_path: str = None):
         pdf.cell(col_width_half, line_height, company_name_for_header, 0, 1, "L")
 
         temp_x_offset = pdf.get_x()
-        pdf.multi_cell(col_width_half, line_height, "\n".join(company_shipping_address_pdf_lines), 0, "L")
+        pdf.multi_cell(col_width_half, line_height, "
+".join(company_shipping_address_pdf_lines), 0, "L")
         y_after_company_address = pdf.get_y()
         pdf.set_xy(temp_x_offset, y_after_company_address)
 
@@ -153,11 +107,17 @@ def generate_invoice_pdf(sales_document_id: int, output_path: str = None):
 
             if customer_address:
                 pdf.set_x(right_column_x)
-                pdf.multi_cell(col_width_half, line_height,
-                               f"{customer_address.street or ''}\n"
-                               f"{customer_address.city or ''}, {customer_address.state or ''} {customer_address.zip_code or ''}\n"
-                               f"{customer_address.country or ''}".strip(),
-                               0, "L")
+                pdf.multi_cell(
+                    col_width_half,
+                    line_height,
+                    f"{customer_address.street or ''}
+"
+                    f"{customer_address.city or ''}, {customer_address.state or ''} {customer_address.zip_code or ''}
+"
+                    f"{customer_address.country or ''}".strip(),
+                    0,
+                    "L",
+                )
             else:
                 pdf.set_x(right_column_x)
                 pdf.cell(col_width_half, line_height, "No address on file.", 0, 1, "L")
@@ -206,7 +166,14 @@ def generate_invoice_pdf(sales_document_id: int, output_path: str = None):
 
                 pdf.set_xy(start_x + desc_col, start_y)
 
-                pdf.cell(qty_col, end_y_desc - start_y, f"{item.quantity:.2f}" if item.quantity is not None else "0.00", 1, 0, "R")
+                pdf.cell(
+                    qty_col,
+                    end_y_desc - start_y,
+                    f"{item.quantity:.2f}" if item.quantity is not None else "0.00",
+                    1,
+                    0,
+                    "R",
+                )
                 pdf.cell(price_col, end_y_desc - start_y, f"${effective_unit_price:.2f}", 1, 0, "R")
                 pdf.cell(total_col, end_y_desc - start_y, f"${item_total:.2f}", 1, 0, "R")
                 pdf.ln(end_y_desc - start_y)
@@ -246,6 +213,7 @@ def generate_invoice_pdf(sales_document_id: int, output_path: str = None):
         if db_handler:
             db_handler.close()
 
+
 def main():
     parser = argparse.ArgumentParser(description="Generate an Invoice PDF from existing application data.")
     parser.add_argument("sales_document_id", type=int, help="The ID of the sales document to generate.")
@@ -256,6 +224,7 @@ def main():
         generate_invoice_pdf(args.sales_document_id, args.output)
     else:
         parser.print_help()
+
 
 if __name__ == "__main__":
     main()

--- a/core/quote_generator.py
+++ b/core/quote_generator.py
@@ -92,8 +92,13 @@ def generate_quote_pdf(sales_document_id: int, output_path: str = None):
         pdf.cell(col_width_half, line_height, company_name_for_header, 0, 1, "L")
 
         temp_x_offset = pdf.get_x()
-        pdf.multi_cell(col_width_half, line_height, "
-".join(company_shipping_address_pdf_lines), 0, "L")
+        pdf.multi_cell(
+            col_width_half,
+            line_height,
+            "\n".join(company_shipping_address_pdf_lines),
+            0,
+            "L",
+        )
         y_after_company_address = pdf.get_y()
         pdf.set_xy(temp_x_offset, y_after_company_address)
 
@@ -116,14 +121,15 @@ def generate_quote_pdf(sales_document_id: int, output_path: str = None):
 
             if customer_billing_address:
                 pdf.set_x(right_column_x)
+                billing_lines = [
+                    customer_billing_address.street or "",
+                    f"{customer_billing_address.city or ''}, {customer_billing_address.state or ''} {customer_billing_address.zip_code or ''}",
+                    (customer_billing_address.country or "").strip(),
+                ]
                 pdf.multi_cell(
                     col_width_half,
                     line_height,
-                    f"{customer_billing_address.street or ''}
-"
-                    f"{customer_billing_address.city or ''}, {customer_billing_address.state or ''} {customer_billing_address.zip_code or ''}
-"
-                    f"{customer_billing_address.country or ''}".strip(),
+                    "\n".join(filter(None, billing_lines)),
                     0,
                     "L",
                 )

--- a/core/quote_generator.py
+++ b/core/quote_generator.py
@@ -13,7 +13,12 @@ from core.sales_logic import SalesLogic
 from core.address_book_logic import AddressBookLogic
 from shared.structs import SalesDocument, SalesDocumentItem, Account, Address
 from shared.utils import sanitize_filename
-from core.pdf_generator import PDF
+from core.pdf_generator import PDF, get_company_pdf_context
+from core.company_repository import CompanyRepository
+from core.company_service import CompanyService
+from core.address_service import AddressService
+from core.repositories import AddressRepository, AccountRepository
+
 
 def generate_quote_pdf(sales_document_id: int, output_path: str = None):
     db_handler = None
@@ -22,75 +27,23 @@ def generate_quote_pdf(sales_document_id: int, output_path: str = None):
         sales_logic = SalesLogic(db_handler)
         address_book_logic = AddressBookLogic(db_handler)
 
+        address_repo = AddressRepository(db_handler)
+        account_repo = AccountRepository(db_handler)
+        address_service = AddressService(address_repo, account_repo)
+        company_repo = CompanyRepository(db_handler)
+        company_service = CompanyService(company_repo, address_service)
+
         doc: SalesDocument = sales_logic.get_sales_document_details(sales_document_id)
         if not doc:
             print(f"Error: Sales document with ID {sales_document_id} not found.")
             return
 
-        company_info_dict = db_handler.get_company_information()
-        company_name_for_header = "Your Company Name"
-        company_phone_pdf = ""
-        company_shipping_address_pdf_lines = ["Shipping address not found."]
-        company_billing_address_pdf_lines = ["Billing address not found."]
-
-        if company_info_dict:
-            company_name_for_header = company_info_dict.get('name', company_name_for_header)
-            company_phone_pdf = company_info_dict.get('phone', "")
-
-            company_shipping_address_id = company_info_dict.get('shipping_address_id')
-            if company_shipping_address_id:
-                addr_tuple = db_handler.get_address(company_shipping_address_id)
-                if addr_tuple:
-                    company_shipping_address_pdf_lines = [
-                        addr_tuple[0] or "",
-                        f"{addr_tuple[1] or ""}, {addr_tuple[2] or ""} {addr_tuple[3] or ""}",
-                        addr_tuple[4] or ""
-                    ]
-                    company_shipping_address_pdf_lines = [line for line in company_shipping_address_pdf_lines if line.strip()]
-                    if not company_shipping_address_pdf_lines:
-                         company_shipping_address_pdf_lines = ["Shipping address details missing."]
-                else:
-                    company_shipping_address_pdf_lines = ["Shipping address not found in DB (ID existed)."]
-            else:
-                temp_billing_id_for_shipping = company_info_dict.get('billing_address_id')
-                if temp_billing_id_for_shipping:
-                    company_shipping_address_pdf_lines = ["Shipping address not set, using Billing Address:"]
-                    addr_tuple = db_handler.get_address(temp_billing_id_for_shipping)
-                    if addr_tuple:
-                        shipping_fallback_lines = [
-                            addr_tuple[0] or "",
-                            f"{addr_tuple[1] or ""}, {addr_tuple[2] or ""} {addr_tuple[3] or ""}",
-                            addr_tuple[4] or ""
-                        ]
-                        shipping_fallback_lines = [line for line in shipping_fallback_lines if line.strip()]
-                        if not shipping_fallback_lines:
-                            company_shipping_address_pdf_lines = ["Shipping address not set, billing address details missing."]
-                        else:
-                            company_shipping_address_pdf_lines.extend(shipping_fallback_lines)
-                    else:
-                         company_shipping_address_pdf_lines = ["Shipping address not set, billing address not found."]
-                else:
-                    company_shipping_address_pdf_lines = ["No shipping or billing address configured for company."]
-
-            company_billing_address_id = company_info_dict.get('billing_address_id')
-            if company_billing_address_id:
-                addr_tuple = db_handler.get_address(company_billing_address_id)
-                if addr_tuple:
-                    company_billing_address_pdf_lines = [
-                        addr_tuple[0] or "",
-                        f"{addr_tuple[1] or ""}, {addr_tuple[2] or ""} {addr_tuple[3] or ""}",
-                        addr_tuple[4] or ""
-                    ]
-                    company_billing_address_pdf_lines = [line for line in company_billing_address_pdf_lines if line.strip()]
-                    if not company_billing_address_pdf_lines:
-                        company_billing_address_pdf_lines = ["Billing address details missing."]
-                else:
-                    company_billing_address_pdf_lines = ["Billing address not found in DB (ID existed)."]
-            else:
-                company_billing_address_pdf_lines = ["Billing address ID not configured for company."]
-        else:
-            company_shipping_address_pdf_lines = ["Company information not found in database."]
-            company_billing_address_pdf_lines = ["Company information not found in database."]
+        (
+            company_name_for_header,
+            company_phone_pdf,
+            company_shipping_address_pdf_lines,
+            company_billing_address_pdf_lines,
+        ) = get_company_pdf_context(company_service)
 
         customer: Account = None
         customer_billing_address: Address = None
@@ -103,12 +56,10 @@ def generate_quote_pdf(sales_document_id: int, output_path: str = None):
                         customer_billing_address = address
                     if address.address_type == 'Shipping' and address.is_primary:
                         customer_shipping_address = address
-                # Fallback if no primary is set
                 if not customer_billing_address and any(addr.address_type == 'Billing' for addr in customer.addresses):
                     customer_billing_address = next(addr for addr in customer.addresses if addr.address_type == 'Billing')
                 if not customer_shipping_address and any(addr.address_type == 'Shipping' for addr in customer.addresses):
                     customer_shipping_address = next(addr for addr in customer.addresses if addr.address_type == 'Shipping')
-
 
         items: list[SalesDocumentItem] = sales_logic.get_items_for_sales_document(doc.id)
 
@@ -116,7 +67,7 @@ def generate_quote_pdf(sales_document_id: int, output_path: str = None):
             document_number=doc.document_number,
             company_name=company_name_for_header,
             company_billing_address_lines=company_billing_address_pdf_lines,
-            document_type="Quote"
+            document_type="Quote",
         )
         pdf.alias_nb_pages()
         pdf.add_page()
@@ -141,7 +92,8 @@ def generate_quote_pdf(sales_document_id: int, output_path: str = None):
         pdf.cell(col_width_half, line_height, company_name_for_header, 0, 1, "L")
 
         temp_x_offset = pdf.get_x()
-        pdf.multi_cell(col_width_half, line_height, "\n".join(company_shipping_address_pdf_lines), 0, "L")
+        pdf.multi_cell(col_width_half, line_height, "
+".join(company_shipping_address_pdf_lines), 0, "L")
         y_after_company_address = pdf.get_y()
         pdf.set_xy(temp_x_offset, y_after_company_address)
 
@@ -164,11 +116,17 @@ def generate_quote_pdf(sales_document_id: int, output_path: str = None):
 
             if customer_billing_address:
                 pdf.set_x(right_column_x)
-                pdf.multi_cell(col_width_half, line_height,
-                               f"{customer_billing_address.street or ''}\n"
-                               f"{customer_billing_address.city or ''}, {customer_billing_address.state or ''} {customer_billing_address.zip_code or ''}\n"
-                               f"{customer_billing_address.country or ''}".strip(),
-                               0, "L")
+                pdf.multi_cell(
+                    col_width_half,
+                    line_height,
+                    f"{customer_billing_address.street or ''}
+"
+                    f"{customer_billing_address.city or ''}, {customer_billing_address.state or ''} {customer_billing_address.zip_code or ''}
+"
+                    f"{customer_billing_address.country or ''}".strip(),
+                    0,
+                    "L",
+                )
             else:
                 pdf.set_x(right_column_x)
                 pdf.cell(col_width_half, line_height, "No billing address on file.", 0, 1, "L")
@@ -257,6 +215,7 @@ def generate_quote_pdf(sales_document_id: int, output_path: str = None):
         if db_handler:
             db_handler.close()
 
+
 def main():
     parser = argparse.ArgumentParser(description="Generate a Quote PDF from existing application data.")
     parser.add_argument("sales_document_id", type=int, help="The ID of the sales document to generate.")
@@ -267,6 +226,7 @@ def main():
         generate_quote_pdf(args.sales_document_id, args.output)
     else:
         parser.print_help()
+
 
 if __name__ == "__main__":
     main()

--- a/tests/unit/test_company_service.py
+++ b/tests/unit/test_company_service.py
@@ -1,0 +1,41 @@
+import unittest
+from core.database import DatabaseHandler
+from core.company_repository import CompanyRepository
+from core.company_service import CompanyService
+from core.address_service import AddressService
+from core.repositories import AddressRepository, AccountRepository
+from shared.structs import Address
+
+
+class TestCompanyService(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.db = DatabaseHandler(db_name=':memory:')
+        address_repo = AddressRepository(cls.db)
+        account_repo = AccountRepository(cls.db)
+        cls.address_service = AddressService(address_repo, account_repo)
+        company_repo = CompanyRepository(cls.db)
+        cls.service = CompanyService(company_repo, cls.address_service)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.db.close()
+
+    def test_load_default_company(self):
+        company = self.service.load_company_information()
+        self.assertEqual(company.name, "My Company")
+        self.assertIsNotNone(company.company_id)
+
+    def test_save_company_information(self):
+        company = self.service.load_company_information()
+        company.name = "Service Test Co"
+        company.phone = "555-1234"
+        addr = Address(street="1 Test St", city="Testville", state="TS", zip_code="12345", country="Testland")
+        addr.address_type = "Billing"
+        addr.is_primary = True
+        company.addresses.append(addr)
+        self.service.save_company_information(company)
+        data = self.db.get_company_information()
+        self.assertEqual(data['name'], "Service Test Co")
+        self.assertEqual(data['phone'], "555-1234")
+        self.assertEqual(len(data['addresses']), 1)

--- a/ui/main_view.py
+++ b/ui/main_view.py
@@ -13,6 +13,10 @@ from ui.purchase_documents.purchase_document_tab import PurchaseDocumentTab
 from core.sales_logic import SalesLogic # Import SalesLogic
 from ui.sales_documents.sales_document_tab import SalesDocumentTab # Import SalesDocumentTab
 from ui.company_info_tab import CompanyInfoTab # Import the new tab
+from core.company_repository import CompanyRepository
+from core.company_service import CompanyService
+from core.address_service import AddressService
+from core.repositories import AddressRepository, AccountRepository
 from ui.pricing.pricing_rule_tab import PricingRuleTab
 
 
@@ -30,6 +34,12 @@ class AddressBookView:
         self.purchase_logic = PurchaseLogic(self.db_handler) # Initialize PurchaseLogic
         self.sales_logic = SalesLogic(self.db_handler) # Initialize SalesLogic
 
+        # Initialize services for company info
+        address_repo = AddressRepository(self.db_handler)
+        account_repo = AccountRepository(self.db_handler)
+        self.address_service = AddressService(address_repo, account_repo)
+        company_repo = CompanyRepository(self.db_handler)
+        self.company_service = CompanyService(company_repo, self.address_service)
 
         # Track the currently selected contact's ID and account's ID
         self.selected_contact_id = None
@@ -50,7 +60,7 @@ class AddressBookView:
         self.product_tab = ProductTab(self.notebook, self.address_book_logic, self.product_logic) # Pass product_logic here too
         self.purchase_document_tab = PurchaseDocumentTab(self.notebook, self.purchase_logic, self.address_book_logic, self.product_logic) # Pass product_logic
         self.sales_document_tab = SalesDocumentTab(self.notebook, self.sales_logic, self.address_book_logic, self.product_logic) # Add SalesDocumentTab
-        self.company_info_tab = CompanyInfoTab(self.notebook, self.db_handler) # Add CompanyInfoTab
+        self.company_info_tab = CompanyInfoTab(self.notebook, self.company_service) # Add CompanyInfoTab
         self.pricing_rule_tab = PricingRuleTab(self.notebook, self.address_book_logic)
 
 


### PR DESCRIPTION
## Summary
- add `ICompanyRepository` and `CompanyRepository` for company persistence
- implement `CompanyService` to manage company info and addresses
- refactor CompanyInfoTab and main view to use new service and document repository/service pattern
- add unit tests for `CompanyService`
- refactor PDF generators to fetch company details through the service layer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688cb42e44bc83319299e917a8c858d9