### PR TITLE
Standardize tab actions and left-align buttons

### DIFF
--- a/ui/main_view.py
+++ b/ui/main_view.py
@@ -74,7 +74,7 @@ class AddressBookView:
         self.notebook.add(self.interaction_log_tab, text="Interaction Log")
         self.notebook.add(self.task_tab, text="Tasks")
         self.notebook.add(self.product_tab.frame, text="Products")
-        self.notebook.add(self.purchase_document_tab.frame, text="Purchase Documents")
-        self.notebook.add(self.sales_document_tab.frame, text="Sales Documents") # Add Sales Documents tab
+        self.notebook.add(self.purchase_document_tab.frame, text="Purchase")
+        self.notebook.add(self.sales_document_tab.frame, text="Sales") # Add Sales Documents tab
         self.notebook.add(self.company_info_tab.frame, text="Company Information") # Add the new tab to the notebook
         self.notebook.add(self.pricing_rule_tab.frame, text="Pricing Rules")

--- a/ui/products/product_tab.py
+++ b/ui/products/product_tab.py
@@ -29,22 +29,22 @@ class ProductTab:
 
         button_width = 20
         button_frame = tk.Frame(self.frame)
-        button_frame.grid(row=1, column=0, columnspan=4, pady=5)
+        button_frame.grid(row=1, column=0, columnspan=4, pady=5, sticky="w")
 
-        self.add_product_button = tk.Button(
-            button_frame, text="Add New Product",
+        self.new_button = tk.Button(
+            button_frame, text="New",
             command=self.create_new_product, width=button_width)
-        self.add_product_button.pack(side=tk.LEFT, padx=5)
+        self.new_button.pack(side=tk.LEFT, padx=5)
 
-        self.edit_product_button = tk.Button(
-            button_frame, text="Edit Product",
+        self.edit_button = tk.Button(
+            button_frame, text="Edit",
             command=self.edit_existing_product, width=button_width)
-        self.edit_product_button.pack(side=tk.LEFT, padx=5)
+        self.edit_button.pack(side=tk.LEFT, padx=5)
 
-        self.remove_product_button = tk.Button(
-            button_frame, text="Remove Product",
+        self.delete_button = tk.Button(
+            button_frame, text="Delete",
             command=self.remove_product, width=button_width)
-        self.remove_product_button.pack(side=tk.LEFT, padx=5)
+        self.delete_button.pack(side=tk.LEFT, padx=5)
 
         self.view_categories_button = tk.Button(
             button_frame, text="View Categories",

--- a/ui/purchase_documents/purchase_document_tab.py
+++ b/ui/purchase_documents/purchase_document_tab.py
@@ -23,15 +23,15 @@ class PurchaseDocumentTab:
     def _setup_ui(self):
         # Button frame
         button_frame = ttk.Frame(self.frame)
-        button_frame.pack(pady=10, padx=10, fill=tk.X)
+        button_frame.pack(pady=10, padx=10, fill=tk.X, anchor=tk.W)
 
-        self.add_button = ttk.Button(button_frame, text="New RFQ/PO", command=self.open_new_document_popup)
+        self.add_button = ttk.Button(button_frame, text="New", command=self.open_new_document_popup)
         self.add_button.pack(side=tk.LEFT, padx=5)
 
-        self.edit_button = ttk.Button(button_frame, text="Edit Document", command=self.open_edit_document_popup, state=tk.DISABLED)
+        self.edit_button = ttk.Button(button_frame, text="Edit", command=self.open_edit_document_popup, state=tk.DISABLED)
         self.edit_button.pack(side=tk.LEFT, padx=5)
 
-        self.delete_button = ttk.Button(button_frame, text="Delete Document", command=self.delete_selected_document, state=tk.DISABLED)
+        self.delete_button = ttk.Button(button_frame, text="Delete", command=self.delete_selected_document, state=tk.DISABLED)
         self.delete_button.pack(side=tk.LEFT, padx=5)
 
         # Treeview for displaying documents

--- a/ui/sales_documents/sales_document_tab.py
+++ b/ui/sales_documents/sales_document_tab.py
@@ -18,19 +18,15 @@ class SalesDocumentTab:
 
     def _setup_ui(self):
         button_frame = ttk.Frame(self.frame)
-        button_frame.pack(pady=10, padx=10, fill=tk.X)
+        button_frame.pack(pady=10, padx=10, fill=tk.X, anchor=tk.W)
 
-        # Updated button text for sales context
-        self.new_quote_button = ttk.Button(button_frame, text="New Quote", command=lambda: self.open_manage_document_popup(doc_type=SalesDocumentType.QUOTE))
-        self.new_quote_button.pack(side=tk.LEFT, padx=5)
+        self.new_button = ttk.Button(button_frame, text="New", command=lambda: self.open_manage_document_popup(doc_type=SalesDocumentType.QUOTE))
+        self.new_button.pack(side=tk.LEFT, padx=5)
 
-        self.new_invoice_button = ttk.Button(button_frame, text="New Invoice", command=lambda: self.open_manage_document_popup(doc_type=SalesDocumentType.INVOICE))
-        self.new_invoice_button.pack(side=tk.LEFT, padx=5)
+        self.edit_button = ttk.Button(button_frame, text="Edit", command=lambda: self.open_manage_document_popup(), state=tk.DISABLED)
+        self.edit_button.pack(side=tk.LEFT, padx=5)
 
-        self.manage_button = ttk.Button(button_frame, text="Manage Document", command=lambda: self.open_manage_document_popup())
-        self.manage_button.pack(side=tk.LEFT, padx=5)
-
-        self.delete_button = ttk.Button(button_frame, text="Delete Document", command=self.delete_selected_document, state=tk.DISABLED)
+        self.delete_button = ttk.Button(button_frame, text="Delete", command=self.delete_selected_document, state=tk.DISABLED)
         self.delete_button.pack(side=tk.LEFT, padx=5)
 
         # Adapted columns for sales documents
@@ -120,12 +116,15 @@ class SalesDocumentTab:
             try:
                 self.selected_document_id = int(selected_items[0])
                 self.delete_button.config(state=tk.NORMAL)
+                self.edit_button.config(state=tk.NORMAL)
             except ValueError:
                 self.selected_document_id = None
                 self.delete_button.config(state=tk.DISABLED)
+                self.edit_button.config(state=tk.DISABLED)
         else:
             self.selected_document_id = None
             self.delete_button.config(state=tk.DISABLED)
+            self.edit_button.config(state=tk.DISABLED)
 
     def open_manage_document_popup(self, doc_type=None):
         # Import SalesDocumentPopup locally


### PR DESCRIPTION
## Summary
- Simplify product tab actions to New, Edit, Delete
- Left-align button rows across product, purchase, and sales tabs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d6bb5bb8483318db3528c74e6e6eb