### PR TITLE
Add remittance address type

### DIFF
--- a/core/address_service.py
+++ b/core/address_service.py
@@ -11,21 +11,15 @@ class AddressService:
 
     @staticmethod
     def enforce_single_primary(addresses):
-        """Ensure only one primary address exists for each type."""
-        primary_billing_found = False
-        primary_shipping_found = False
+        """Ensure only one primary address exists per address type."""
+        primary_found = set()
         for address in reversed(addresses):
             if getattr(address, "is_primary", False):
-                if address.address_type == "Billing":
-                    if primary_billing_found:
-                        address.is_primary = False
-                    else:
-                        primary_billing_found = True
-                elif address.address_type == "Shipping":
-                    if primary_shipping_found:
-                        address.is_primary = False
-                    else:
-                        primary_shipping_found = True
+                addr_type = getattr(address, "address_type", None)
+                if addr_type in primary_found:
+                    address.is_primary = False
+                else:
+                    primary_found.add(addr_type)
 
     def add_address(self, street, city, state, zip_code, country):
         """Add a new address and return its ID."""

--- a/tests/unit/test_address_book_logic.py
+++ b/tests/unit/test_address_book_logic.py
@@ -147,7 +147,7 @@ class TestAddressBookLogic(unittest.TestCase):
         # ... rest of test ...
 
     def test_enforce_single_primary_address(self):
-        """Test that only one primary billing and one primary shipping address can be saved for an account."""
+        """Ensure only one primary address per type (Billing, Shipping, Remittance)."""
         from shared.structs import Account, Address
         account = Account(name="Test Account", account_type=AccountType.CUSTOMER)
         self.logic.save_account(account)
@@ -183,6 +183,22 @@ class TestAddressBookLogic(unittest.TestCase):
         addresses = self.db_handler.get_account_addresses(account.account_id)
         primary_shipping_addresses = [addr for addr in addresses if addr['address_type'] == 'Shipping' and addr['is_primary']]
         self.assertEqual(len(primary_shipping_addresses), 1)
+
+        # Add two primary remittance addresses
+        remittance_address1 = Address(street="123 Remit St", city="Remitville", state="RS", zip_code="98765", country="RC")
+        remittance_address1.address_type = "Remittance"
+        remittance_address1.is_primary = True
+        remittance_address2 = Address(street="456 Remit St", city="Remitville", state="RS", zip_code="98765", country="RC")
+        remittance_address2.address_type = "Remittance"
+        remittance_address2.is_primary = True
+        account.addresses.append(remittance_address1)
+        account.addresses.append(remittance_address2)
+        self.logic.save_account_addresses(account)
+
+        # Verify that only one remittance address is primary
+        addresses = self.db_handler.get_account_addresses(account.account_id)
+        primary_remittance_addresses = [addr for addr in addresses if addr['address_type'] == 'Remittance' and addr['is_primary']]
+        self.assertEqual(len(primary_remittance_addresses), 1)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_company_info.py
+++ b/tests/unit/test_company_info.py
@@ -206,7 +206,7 @@ class TestCompanyInfo(unittest.TestCase):
         self.assertEqual(db_entry['name'], "My Company")
 
     def test_07_enforce_single_primary_address(self):
-        """Test that only one primary billing and one primary shipping address can be saved for the company."""
+        """Ensure only one primary address per type (Billing, Shipping, Remittance)."""
         if not self.root:
             self.skipTest("Tkinter root not available, skipping UI-dependent test.")
 
@@ -232,6 +232,16 @@ class TestCompanyInfo(unittest.TestCase):
         tab.company_info.addresses.append(shipping_address1)
         tab.company_info.addresses.append(shipping_address2)
 
+        # Add two primary remittance addresses
+        remittance_address1 = Address(street="123 Remit St", city="Remitville", state="RS", zip_code="98765", country="RC")
+        remittance_address1.address_type = "Remittance"
+        remittance_address1.is_primary = True
+        remittance_address2 = Address(street="456 Remit St", city="Remitville", state="RS", zip_code="98765", country="RC")
+        remittance_address2.address_type = "Remittance"
+        remittance_address2.is_primary = True
+        tab.company_info.addresses.append(remittance_address1)
+        tab.company_info.addresses.append(remittance_address2)
+
         tab.save_company_information()
 
         # Verify that only one of each is primary
@@ -240,6 +250,8 @@ class TestCompanyInfo(unittest.TestCase):
         self.assertEqual(len(primary_billing_addresses), 1)
         primary_shipping_addresses = [addr for addr in addresses if addr['address_type'] == 'Shipping' and addr['is_primary']]
         self.assertEqual(len(primary_shipping_addresses), 1)
+        primary_remittance_addresses = [addr for addr in addresses if addr['address_type'] == 'Remittance' and addr['is_primary']]
+        self.assertEqual(len(primary_remittance_addresses), 1)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/ui/accounts/account_popup.py
+++ b/ui/accounts/account_popup.py
@@ -177,7 +177,13 @@ class AddressPopup(PopupBase):
         self.country_entry = self._create_entry("Country:", 4, self.address.country)
         tk.Label(self, text="Type:").grid(row=5, column=0, padx=5, pady=5, sticky="e")
         self.type_var = tk.StringVar(self)
-        self.type_dropdown = ttk.Combobox(self, textvariable=self.type_var, values=["Billing", "Shipping"], state="readonly", width=37)
+        self.type_dropdown = ttk.Combobox(
+            self,
+            textvariable=self.type_var,
+            values=["Billing", "Shipping", "Remittance"],
+            state="readonly",
+            width=37,
+        )
         if hasattr(self.address, 'address_type'):
             self.type_dropdown.set(self.address.address_type)
         self.type_dropdown.grid(row=5, column=1, padx=5, pady=5)

--- a/ui/company_info_tab.py
+++ b/ui/company_info_tab.py
@@ -139,7 +139,13 @@ class AddressPopup(tk.Toplevel):
         self.country_entry = self._create_entry("Country:", 4, self.address.country)
         tk.Label(self, text="Type:").grid(row=5, column=0, padx=5, pady=5, sticky="e")
         self.type_var = tk.StringVar(self)
-        self.type_dropdown = ttk.Combobox(self, textvariable=self.type_var, values=["Billing", "Shipping"], state="readonly", width=37)
+        self.type_dropdown = ttk.Combobox(
+            self,
+            textvariable=self.type_var,
+            values=["Billing", "Shipping", "Remittance"],
+            state="readonly",
+            width=37,
+        )
         if hasattr(self.address, 'address_type'):
             self.type_dropdown.set(self.address.address_type)
         self.type_dropdown.grid(row=5, column=1, padx=5, pady=5)


### PR DESCRIPTION
## Summary
- allow addresses to be tagged as Remittance in account and company UI
- ensure only one primary address exists per address type
- cover remittance addresses in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d6ed531088331a40c58d7ae15b238