### PR TITLE
Standardize tab names and button layout

### DIFF
--- a/ui/accounts/account_tab.py
+++ b/ui/accounts/account_tab.py
@@ -19,29 +19,45 @@ class AccountTab(TabBase):
         self.bind("<FocusIn>", lambda event: self.load_accounts())
 
     def setup_account_tab(self):
-        """Setup the Account Administration tab with account fields and account list."""
+        """Setup the Accounts tab with account fields and account list."""
         tk.Label(self, text="Accounts").grid(row=0, column=0, padx=5, pady=5, sticky="w")
 
         button_width = 20
 
-        # Add account buttons
+        # Button bar
+        button_frame = tk.Frame(self)
+        button_frame.grid(row=1, column=0, columnspan=3, pady=5, sticky="w")
+
         self.add_account_button = tk.Button(
-            self, text="Add New Account",
-            command=self.create_new_account, width=button_width)
-        self.add_account_button.grid(row=3, column=0, padx=5, pady=5)
+            button_frame,
+            text="New",
+            command=self.create_new_account,
+            width=button_width,
+        )
+        self.add_account_button.pack(side=tk.LEFT, padx=5)
 
         self.edit_account_button = tk.Button(
-            self, text="Edit Account",
-            command=self.edit_existing_account, width=button_width)
-        self.edit_account_button.grid(row=3, column=1, padx=5, pady=5)
+            button_frame,
+            text="Edit",
+            command=self.edit_existing_account,
+            width=button_width,
+        )
+        self.edit_account_button.pack(side=tk.LEFT, padx=5)
 
         self.remove_account_button = tk.Button(
-            self, text="Remove Account",
-            command=self.remove_account, width=button_width)
-        self.remove_account_button.grid(row=3, column=2, padx=5, pady=5)
+            button_frame,
+            text="Delete",
+            command=self.remove_account,
+            width=button_width,
+        )
+        self.remove_account_button.pack(side=tk.LEFT, padx=5)
 
         # Treeview for displaying accounts
-        self.tree = ttk.Treeview(self, columns=("id", "name", "phone", "description", "account_type"), show="headings")
+        self.tree = ttk.Treeview(
+            self,
+            columns=("id", "name", "phone", "description", "account_type"),
+            show="headings",
+        )
         self.tree.column("id", width=0, stretch=False)  # Hidden ID column
         self.tree.heading("name", text="Account Name", command=lambda: self.sort_column("name", False))
         self.tree.heading("phone", text="Phone", command=lambda: self.sort_column("phone", False))
@@ -51,11 +67,11 @@ class AccountTab(TabBase):
         self.tree.column("phone", width=100)
         self.tree.column("description", width=150)
         self.tree.column("account_type", width=100)
-        self.tree.grid(row=7, column=0, columnspan=4, padx=5, pady=5, sticky="nsew")  # Increased columnspan
+        self.tree.grid(row=2, column=0, columnspan=3, padx=5, pady=5, sticky="nsew")
         self.tree.bind("<<TreeviewSelect>>", self.select_account)
 
         # Configure the grid row and column containing the tree to expand
-        self.grid_rowconfigure(7, weight=1)
+        self.grid_rowconfigure(2, weight=1)
         self.grid_columnconfigure(0, weight=1)
 
     def remove_account(self):

--- a/ui/contacts/contact_tab.py
+++ b/ui/contacts/contact_tab.py
@@ -16,25 +16,34 @@ class ContactTab(TabBase):
         self.bind("<FocusIn>", self.load_contacts)
 
     def setup_contact_tab(self):
-        tk.Label(self, text="Contact Management").grid(row=0, column=0, columnspan=3, padx=5, pady=5, sticky="w")
+        tk.Label(self, text="Contacts").grid(row=0, column=0, columnspan=3, padx=5, pady=5, sticky="w")
 
         button_width = 20
         button_frame = tk.Frame(self)
-        button_frame.grid(row=1, column=0, columnspan=3, pady=5)
+        button_frame.grid(row=1, column=0, columnspan=3, pady=5, sticky="w")
 
         self.add_contact_button = tk.Button(
-            button_frame, text="Add New Contact",
-            command=self.create_new_contact, width=button_width)
+            button_frame,
+            text="New",
+            command=self.create_new_contact,
+            width=button_width,
+        )
         self.add_contact_button.pack(side=tk.LEFT, padx=5)
 
         self.edit_contact_button = tk.Button(
-            button_frame, text="Edit Contact",
-            command=self.edit_existing_contact, width=button_width)
+            button_frame,
+            text="Edit",
+            command=self.edit_existing_contact,
+            width=button_width,
+        )
         self.edit_contact_button.pack(side=tk.LEFT, padx=5)
 
         self.remove_contact_button = tk.Button(
-            button_frame, text="Remove Contact",
-            command=self.remove_contact, width=button_width)
+            button_frame,
+            text="Delete",
+            command=self.remove_contact,
+            width=button_width,
+        )
         self.remove_contact_button.pack(side=tk.LEFT, padx=5)
 
         self.tree = ttk.Treeview(self, columns=("id", "name", "phone", "email", "role", "account_name"), show="headings")

--- a/ui/main_view.py
+++ b/ui/main_view.py
@@ -69,8 +69,8 @@ class AddressBookView:
 
 
         # Add frames from tabs to Notebook
-        self.notebook.add(self.account_tab, text="Account Administration")
-        self.notebook.add(self.contact_tab, text="Contact Information")
+        self.notebook.add(self.account_tab, text="Accounts")
+        self.notebook.add(self.contact_tab, text="Contacts")
         self.notebook.add(self.interaction_log_tab, text="Interaction Log")
         self.notebook.add(self.task_tab, text="Tasks")
         self.notebook.add(self.product_tab.frame, text="Products")

--- a/ui/pricing/pricing_rule_tab.py
+++ b/ui/pricing/pricing_rule_tab.py
@@ -19,14 +19,23 @@ class PricingRuleTab:
 
         button_width = 20
 
-        self.add_button = tk.Button(self.frame, text="New Rule", command=self.create_new_rule, width=button_width)
-        self.add_button.grid(row=1, column=0, padx=5, pady=5)
+        button_frame = tk.Frame(self.frame)
+        button_frame.grid(row=1, column=0, columnspan=3, pady=5, sticky="w")
 
-        self.edit_button = tk.Button(self.frame, text="Edit Rule", command=self.edit_existing_rule, width=button_width)
-        self.edit_button.grid(row=1, column=1, padx=5, pady=5)
+        self.add_button = tk.Button(
+            button_frame, text="New", command=self.create_new_rule, width=button_width
+        )
+        self.add_button.pack(side=tk.LEFT, padx=5)
 
-        self.delete_button = tk.Button(self.frame, text="Delete Rule", command=self.delete_rule, width=button_width)
-        self.delete_button.grid(row=1, column=2, padx=5, pady=5)
+        self.edit_button = tk.Button(
+            button_frame, text="Edit", command=self.edit_existing_rule, width=button_width
+        )
+        self.edit_button.pack(side=tk.LEFT, padx=5)
+
+        self.delete_button = tk.Button(
+            button_frame, text="Delete", command=self.delete_rule, width=button_width
+        )
+        self.delete_button.pack(side=tk.LEFT, padx=5)
 
         self.tree = ttk.Treeview(self.frame, columns=("id", "name", "markup", "fixed_price"), show="headings")
         self.tree.column("id", width=0, stretch=False)


### PR DESCRIPTION
## Summary
- Rename account and contact tabs to "Accounts" and "Contacts"
- Simplify button labels to New/Edit/Delete and left-align them across accounts, contacts, and pricing rules tabs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d71dd3de48331b0ea28e185652668