### PR TITLE
Add fixed markup pricing option

### DIFF
--- a/core/address_book_logic.py
+++ b/core/address_book_logic.py
@@ -781,16 +781,14 @@ class AddressBookLogic:
         return {cat_id: (name, parent_id) for cat_id, name, parent_id in categories_data}
 
     # --- Pricing Rule Methods ---
-    def create_pricing_rule(self, rule_name: str, markup_percentage: float = None, fixed_price: float = None) -> Optional[int]:
+    def create_pricing_rule(self, rule_name: str, markup_percentage: float = None, fixed_markup: float = None) -> Optional[int]:
         """Creates a new pricing rule."""
         if not rule_name:
             raise ValueError("Rule name cannot be empty.")
-        if markup_percentage is None and fixed_price is None:
-            raise ValueError("Either markup_percentage or fixed_price must be provided.")
-        if markup_percentage is not None and fixed_price is not None:
-            raise ValueError("Provide either markup_percentage or fixed_price, not both.")
+        if markup_percentage is None and fixed_markup is None:
+            raise ValueError("Either markup_percentage or fixed_markup must be provided.")
 
-        return self.product_repo.add_pricing_rule(rule_name, markup_percentage, fixed_price)
+        return self.product_repo.add_pricing_rule(rule_name, markup_percentage, fixed_markup)
 
     def get_pricing_rule(self, rule_id: int) -> Optional[PricingRule]:
         """Retrieves a pricing rule by its ID."""
@@ -800,7 +798,7 @@ class AddressBookLogic:
                 rule_id=rule_data['rule_id'],
                 rule_name=rule_data['rule_name'],
                 markup_percentage=rule_data['markup_percentage'],
-                fixed_price=rule_data['fixed_price']
+                fixed_markup=rule_data['fixed_markup']
             )
         return None
 
@@ -811,19 +809,17 @@ class AddressBookLogic:
             rule_id=rule_data['rule_id'],
             rule_name=rule_data['rule_name'],
             markup_percentage=rule_data['markup_percentage'],
-            fixed_price=rule_data['fixed_price']
+            fixed_markup=rule_data['fixed_markup']
         ) for rule_data in rules_data]
 
-    def update_pricing_rule(self, rule_id: int, rule_name: str = None, markup_percentage: float = None, fixed_price: float = None):
+    def update_pricing_rule(self, rule_id: int, rule_name: str = None, markup_percentage: float = None, fixed_markup: float = None):
         """Updates a pricing rule."""
         if not rule_name:
             raise ValueError("Rule name cannot be empty.")
-        if markup_percentage is None and fixed_price is None:
-            raise ValueError("Either markup_percentage or fixed_price must be provided.")
-        if markup_percentage is not None and fixed_price is not None:
-            raise ValueError("Provide either markup_percentage or fixed_price, not both.")
+        if markup_percentage is None and fixed_markup is None:
+            raise ValueError("Either markup_percentage or fixed_markup must be provided.")
 
-        self.product_repo.update_pricing_rule(rule_id, rule_name, markup_percentage, fixed_price)
+        self.product_repo.update_pricing_rule(rule_id, rule_name, markup_percentage, fixed_markup)
 
     def delete_pricing_rule(self, rule_id: int):
         """Deletes a pricing rule."""

--- a/core/database.py
+++ b/core/database.py
@@ -943,12 +943,12 @@ class DatabaseHandler:
         return self.cursor.fetchall()
 
 # --- Pricing Rule CRUD Methods ---
-    def add_pricing_rule(self, rule_name: str, markup_percentage: float | None, fixed_price: float | None) -> int:
+    def add_pricing_rule(self, rule_name: str, markup_percentage: float | None, fixed_markup: float | None) -> int:
         """Adds a new pricing rule and returns its ID."""
         self.cursor.execute("""
-            INSERT INTO pricing_rules (rule_name, markup_percentage, fixed_price)
+            INSERT INTO pricing_rules (rule_name, markup_percentage, fixed_markup)
             VALUES (?, ?, ?)
-        """, (rule_name, markup_percentage, fixed_price))
+        """, (rule_name, markup_percentage, fixed_markup))
         self.conn.commit()
         return self.cursor.lastrowid
 
@@ -963,13 +963,13 @@ class DatabaseHandler:
         self.cursor.execute("SELECT * FROM pricing_rules ORDER BY rule_name")
         return [dict(row) for row in self.cursor.fetchall()]
 
-    def update_pricing_rule(self, rule_id: int, rule_name: str, markup_percentage: float | None, fixed_price: float | None):
+    def update_pricing_rule(self, rule_id: int, rule_name: str, markup_percentage: float | None, fixed_markup: float | None):
         """Updates a pricing rule."""
         self.cursor.execute("""
             UPDATE pricing_rules
-            SET rule_name = ?, markup_percentage = ?, fixed_price = ?
+            SET rule_name = ?, markup_percentage = ?, fixed_markup = ?
             WHERE rule_id = ?
-        """, (rule_name, markup_percentage, fixed_price, rule_id))
+        """, (rule_name, markup_percentage, fixed_markup, rule_id))
         self.conn.commit()
 
     def delete_pricing_rule(self, rule_id: int):

--- a/core/repositories.py
+++ b/core/repositories.py
@@ -124,8 +124,8 @@ class ProductRepository:
         return self.db.add_product_unit_of_measure(name)
 
     # Pricing rules
-    def add_pricing_rule(self, rule_name, markup_percentage=None, fixed_price=None):
-        return self.db.add_pricing_rule(rule_name, markup_percentage, fixed_price)
+    def add_pricing_rule(self, rule_name, markup_percentage=None, fixed_markup=None):
+        return self.db.add_pricing_rule(rule_name, markup_percentage, fixed_markup)
 
     def get_pricing_rule(self, rule_id):
         return self.db.get_pricing_rule(rule_id)
@@ -133,8 +133,8 @@ class ProductRepository:
     def get_all_pricing_rules(self):
         return self.db.get_all_pricing_rules()
 
-    def update_pricing_rule(self, rule_id, rule_name, markup_percentage=None, fixed_price=None):
-        self.db.update_pricing_rule(rule_id, rule_name, markup_percentage, fixed_price)
+    def update_pricing_rule(self, rule_id, rule_name, markup_percentage=None, fixed_markup=None):
+        self.db.update_pricing_rule(rule_id, rule_name, markup_percentage, fixed_markup)
 
     def delete_pricing_rule(self, rule_id):
         self.db.delete_pricing_rule(rule_id)

--- a/core/sales_logic.py
+++ b/core/sales_logic.py
@@ -137,14 +137,14 @@ class SalesLogic:
             if customer and customer.pricing_rule_id:
                 rule = address_book_logic.get_pricing_rule(customer.pricing_rule_id)
                 if rule:
-                    if rule.fixed_price is not None:
-                        final_unit_price = rule.fixed_price
-                    elif rule.markup_percentage is not None:
-                        product_cost = product_info.get('cost')
-                        if product_cost is not None:
-                            final_unit_price = product_cost * (1 + rule.markup_percentage / 100)
-                        else:
-                            raise ValueError(f"Product cost for product ID {product_id} not found, cannot apply markup rule.")
+                    product_cost = product_info.get('cost')
+                    if product_cost is None:
+                        raise ValueError(f"Product cost for product ID {product_id} not found, cannot apply pricing rule.")
+                    final_unit_price = product_cost
+                    if rule.fixed_markup is not None:
+                        final_unit_price += rule.fixed_markup
+                    if rule.markup_percentage is not None:
+                        final_unit_price *= (1 + rule.markup_percentage / 100)
 
             if final_unit_price is None: # If no rule was applied or customer/rule not found
                 final_unit_price = product_info.get('sale_price')
@@ -209,14 +209,14 @@ class SalesLogic:
             if customer and customer.pricing_rule_id:
                 rule = address_book_logic.get_pricing_rule(customer.pricing_rule_id)
                 if rule:
-                    if rule.fixed_price is not None:
-                        final_unit_price = rule.fixed_price
-                    elif rule.markup_percentage is not None:
-                        product_cost = product_info.get('cost')
-                        if product_cost is not None:
-                            final_unit_price = product_cost * (1 + rule.markup_percentage / 100)
-                        else:
-                            raise ValueError(f"Product cost for product ID {product_id} not found, cannot apply markup rule.")
+                    product_cost = product_info.get('cost')
+                    if product_cost is None:
+                        raise ValueError(f"Product cost for product ID {product_id} not found, cannot apply pricing rule.")
+                    final_unit_price = product_cost
+                    if rule.fixed_markup is not None:
+                        final_unit_price += rule.fixed_markup
+                    if rule.markup_percentage is not None:
+                        final_unit_price *= (1 + rule.markup_percentage / 100)
 
             if final_unit_price is None: # If no rule was applied or customer/rule not found
                 final_unit_price = product_info.get('sale_price')
@@ -380,14 +380,15 @@ class SalesLogic:
         if customer and customer.pricing_rule_id:
             rule = address_book_logic.get_pricing_rule(customer.pricing_rule_id)
             if rule:
-                if rule.fixed_price is not None:
-                    final_unit_price = rule.fixed_price
-                elif rule.markup_percentage is not None:
-                    product_info = self.product_repo.get_product_details(product_id)
-                    if product_info:
-                        product_cost = product_info.get('cost')
-                        if product_cost is not None:
-                            final_unit_price = product_cost * (1 + rule.markup_percentage / 100)
+                product_info = self.product_repo.get_product_details(product_id)
+                if product_info:
+                    product_cost = product_info.get('cost')
+                    if product_cost is not None:
+                        final_unit_price = product_cost
+                        if rule.fixed_markup is not None:
+                            final_unit_price += rule.fixed_markup
+                        if rule.markup_percentage is not None:
+                            final_unit_price *= (1 + rule.markup_percentage / 100)
 
         if final_unit_price is None:
             product_info = self.product_repo.get_product_details(product_id)

--- a/core/schema/common.py
+++ b/core/schema/common.py
@@ -18,8 +18,8 @@ def create_schema(cursor: sqlite3.Cursor) -> None:
             rule_id INTEGER PRIMARY KEY AUTOINCREMENT,
             rule_name TEXT UNIQUE NOT NULL,
             markup_percentage FLOAT,
-            fixed_price FLOAT,
+            fixed_markup FLOAT,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            CONSTRAINT either_markup_or_fixed CHECK (markup_percentage IS NOT NULL OR fixed_price IS NOT NULL)
+            CONSTRAINT either_markup_or_fixed CHECK (markup_percentage IS NOT NULL OR fixed_markup IS NOT NULL)
         )
     """)

--- a/shared/structs.py
+++ b/shared/structs.py
@@ -9,18 +9,18 @@ from .interaction_structs import InteractionType, Interaction
 from .task_structs import TaskStatus, TaskPriority, Task
 
 class PricingRule:
-    def __init__(self, rule_id: int | None = None, rule_name: str = "", markup_percentage: float | None = None, fixed_price: float | None = None):
+    def __init__(self, rule_id: int | None = None, rule_name: str = "", markup_percentage: float | None = None, fixed_markup: float | None = None):
         self.rule_id = rule_id
         self.rule_name = rule_name
         self.markup_percentage = markup_percentage
-        self.fixed_price = fixed_price
+        self.fixed_markup = fixed_markup
 
     def to_dict(self) -> dict:
         return {
             "rule_id": self.rule_id,
             "rule_name": self.rule_name,
             "markup_percentage": self.markup_percentage,
-            "fixed_price": self.fixed_price,
+            "fixed_markup": self.fixed_markup,
         }
 
 class Product:

--- a/tests/unit/test_sales_logic.py
+++ b/tests/unit/test_sales_logic.py
@@ -523,9 +523,9 @@ class TestSalesLogicWithPricingRules(unittest.TestCase):
     def tearDown(self):
         self.db_handler.close()
 
-    def test_add_item_with_fixed_price_rule(self):
-        """Test adding an item for a customer with a fixed price rule."""
-        rule_id = self.address_book_logic.create_pricing_rule(rule_name="Fixed Price Rule", fixed_price=120.0)
+    def test_add_item_with_fixed_markup_rule(self):
+        """Test adding an item for a customer with a fixed markup rule."""
+        rule_id = self.address_book_logic.create_pricing_rule(rule_name="Fixed Markup Rule", fixed_markup=20.0)
         self.address_book_logic.assign_pricing_rule(self.customer.account_id, rule_id)
 
         item = self.sales_logic.add_item_to_sales_document(self.quote.id, self.product.product_id, 1)
@@ -542,6 +542,16 @@ class TestSalesLogicWithPricingRules(unittest.TestCase):
         # cost is 100.0, markup is 25%, so price should be 125.0
         self.assertEqual(item.unit_price, 125.0)
 
+    def test_add_item_with_combined_rule(self):
+        """Test adding an item for a customer with both fixed and percentage markup."""
+        rule_id = self.address_book_logic.create_pricing_rule(rule_name="Combined Rule", fixed_markup=10.0, markup_percentage=20.0)
+        self.address_book_logic.assign_pricing_rule(self.customer.account_id, rule_id)
+
+        item = self.sales_logic.add_item_to_sales_document(self.quote.id, self.product.product_id, 1)
+
+        # cost 100 + fixed 10 = 110; 20% markup -> 132
+        self.assertEqual(item.unit_price, 132.0)
+
     def test_add_item_with_no_rule(self):
         """Test adding an item for a customer with no pricing rule."""
         item = self.sales_logic.add_item_to_sales_document(self.quote.id, self.product.product_id, 1)
@@ -551,7 +561,7 @@ class TestSalesLogicWithPricingRules(unittest.TestCase):
 
     def test_update_item_with_pricing_rule(self):
         """Test that updating an item still respects the pricing rule."""
-        rule_id = self.address_book_logic.create_pricing_rule(rule_name="Fixed Price Rule", fixed_price=110.0)
+        rule_id = self.address_book_logic.create_pricing_rule(rule_name="Fixed Markup Rule", fixed_markup=10.0)
         self.address_book_logic.assign_pricing_rule(self.customer.account_id, rule_id)
 
         item = self.sales_logic.add_item_to_sales_document(self.quote.id, self.product.product_id, 1)

--- a/ui/pricing/pricing_rule_popup.py
+++ b/ui/pricing/pricing_rule_popup.py
@@ -18,7 +18,7 @@ class PricingRulePopup(PopupBase):
 
         self.name_entry = self._create_entry("Rule Name:", 0, self.rule.rule_name)
         self.markup_entry = self._create_entry("Markup %:", 1, self.rule.markup_percentage)
-        self.fixed_price_entry = self._create_entry("Fixed Price:", 2, self.rule.fixed_price)
+        self.fixed_markup_entry = self._create_entry("Fixed Markup:", 2, self.rule.fixed_markup)
 
         save_button = tk.Button(self, text="Save", command=self.save_rule)
         save_button.grid(row=3, column=0, columnspan=2, pady=10)
@@ -28,7 +28,7 @@ class PricingRulePopup(PopupBase):
         if not self.validate_not_empty(rule_name, "Rule name"):
             return
         markup_str = self.markup_entry.get()
-        fixed_price_str = self.fixed_price_entry.get()
+        fixed_markup_str = self.fixed_markup_entry.get()
 
         markup = None
         if markup_str:
@@ -38,29 +38,25 @@ class PricingRulePopup(PopupBase):
                 messagebox.showerror("Error", "Markup percentage must be a number.")
                 return
 
-        fixed_price = None
-        if fixed_price_str:
+        fixed_markup = None
+        if fixed_markup_str:
             try:
-                fixed_price = float(fixed_price_str)
+                fixed_markup = float(fixed_markup_str)
             except ValueError:
-                messagebox.showerror("Error", "Fixed price must be a number.")
+                messagebox.showerror("Error", "Fixed markup must be a number.")
                 return
 
-        if markup is None and fixed_price is None:
-            messagebox.showerror("Error", "Either markup or fixed price must be provided.")
-            return
-
-        if markup is not None and fixed_price is not None:
-            messagebox.showerror("Error", "Provide either markup or fixed price, not both.")
+        if markup is None and fixed_markup is None:
+            messagebox.showerror("Error", "Either markup or fixed markup must be provided.")
             return
 
         self.rule.rule_name = rule_name
         self.rule.markup_percentage = markup
-        self.rule.fixed_price = fixed_price
+        self.rule.fixed_markup = fixed_markup
 
         if self.rule_id is None:
-            self.logic.create_pricing_rule(self.rule.rule_name, self.rule.markup_percentage, self.rule.fixed_price)
+            self.logic.create_pricing_rule(self.rule.rule_name, self.rule.markup_percentage, self.rule.fixed_markup)
         else:
-            self.logic.update_pricing_rule(self.rule.rule_id, self.rule.rule_name, self.rule.markup_percentage, self.rule.fixed_price)
+            self.logic.update_pricing_rule(self.rule.rule_id, self.rule.rule_name, self.rule.markup_percentage, self.rule.fixed_markup)
 
         self.destroy()

--- a/ui/pricing/pricing_rule_tab.py
+++ b/ui/pricing/pricing_rule_tab.py
@@ -37,11 +37,11 @@ class PricingRuleTab:
         )
         self.delete_button.pack(side=tk.LEFT, padx=5)
 
-        self.tree = ttk.Treeview(self.frame, columns=("id", "name", "markup", "fixed_price"), show="headings")
+        self.tree = ttk.Treeview(self.frame, columns=("id", "name", "markup", "fixed_markup"), show="headings")
         self.tree.column("id", width=0, stretch=False)
         self.tree.heading("name", text="Rule Name")
         self.tree.heading("markup", text="Markup %")
-        self.tree.heading("fixed_price", text="Fixed Price")
+        self.tree.heading("fixed_markup", text="Fixed Markup")
         self.tree.grid(row=2, column=0, columnspan=3, padx=5, pady=5, sticky="nsew")
         self.tree.bind("<<TreeviewSelect>>", self.select_rule)
 
@@ -58,7 +58,7 @@ class PricingRuleTab:
                 rule.rule_id,
                 rule.rule_name,
                 f"{rule.markup_percentage:.2f}" if rule.markup_percentage is not None else "N/A",
-                f"${rule.fixed_price:.2f}" if rule.fixed_price is not None else "N/A",
+                f"${rule.fixed_markup:.2f}" if rule.fixed_markup is not None else "N/A",
             ))
 
     def select_rule(self, event=None):


### PR DESCRIPTION
## Summary
- support `fixed_markup` in pricing rules alongside percentage markup
- compute sale price by adding fixed markup before applying percentage
- update pricing rule UI to show "Fixed Markup"

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e27c3fde483318c87b6850b0d7752