### PR TITLE
feat: soft delete and inactive filters for documents

### DIFF
--- a/core/sales_logic.py
+++ b/core/sales_logic.py
@@ -56,7 +56,7 @@ class SalesLogic:
         The numbering is shared across all sales documents regardless of type.
         """
         prefix = "S"
-        all_docs_raw = self.sales_repo.get_all_sales_documents()
+        all_docs_raw = self.sales_repo.get_all_sales_documents(is_active=None)
         max_seq = -1
         for doc_dict in all_docs_raw:
             doc_num_str = doc_dict.get("document_number")
@@ -401,72 +401,103 @@ class SalesLogic:
         doc_data = self.sales_repo.get_sales_document_by_id(doc_id)
         if doc_data:
             status_enum = None
-            if doc_data.get('status'):
+            if doc_data.get("status"):
                 try:
-                    status_enum = SalesDocumentStatus(doc_data['status'])
+                    status_enum = SalesDocumentStatus(doc_data["status"])
                 except ValueError:
-                    logger.warning("Invalid sales status '%s' in DB for doc ID %s", doc_data['status'], doc_id)
+                    logger.warning(
+                        "Invalid sales status '%s' in DB for doc ID %s",
+                        doc_data["status"],
+                        doc_id,
+                    )
 
             doc_type_enum = None
-            if doc_data.get('document_type'):
+            if doc_data.get("document_type"):
                 try:
-                    doc_type_enum = SalesDocumentType(doc_data['document_type'])
+                    doc_type_enum = SalesDocumentType(doc_data["document_type"])
                 except ValueError:
-                    logger.warning("Invalid sales document type '%s' in DB for doc ID %s", doc_data['document_type'], doc_id)
+                    logger.warning(
+                        "Invalid sales document type '%s' in DB for doc ID %s",
+                        doc_data["document_type"],
+                        doc_id,
+                    )
 
             return SalesDocument(
-                doc_id=doc_data['id'],
-                document_number=doc_data['document_number'],
-                customer_id=doc_data['customer_id'],
+                doc_id=doc_data["id"],
+                document_number=doc_data["document_number"],
+                customer_id=doc_data["customer_id"],
                 document_type=doc_type_enum,
-                created_date=doc_data['created_date'],
-                expiry_date=doc_data.get('expiry_date'),
-                due_date=doc_data.get('due_date'),
+                created_date=doc_data["created_date"],
+                expiry_date=doc_data.get("expiry_date"),
+                due_date=doc_data.get("due_date"),
                 status=status_enum,
-                notes=doc_data.get('notes'),
-                subtotal=doc_data.get('subtotal'),
-                taxes=doc_data.get('taxes'),
-                total_amount=doc_data.get('total_amount'),
-                related_quote_id=doc_data.get('related_quote_id')
+                notes=doc_data.get("notes"),
+                subtotal=doc_data.get("subtotal"),
+                taxes=doc_data.get("taxes"),
+                total_amount=doc_data.get("total_amount"),
+                related_quote_id=doc_data.get("related_quote_id"),
+                is_active=bool(doc_data.get("is_active", True)),
             )
         return None
 
-    def get_all_sales_documents_by_criteria(self, customer_id: int = None, doc_type: SalesDocumentType = None, status: SalesDocumentStatus = None) -> List[SalesDocument]:
+    def get_all_sales_documents_by_criteria(
+        self,
+        customer_id: int = None,
+        doc_type: SalesDocumentType = None,
+        status: SalesDocumentStatus = None,
+        is_active: Optional[bool] = True,
+    ) -> List[SalesDocument]:
         doc_type_value = doc_type.value if doc_type else None
         status_value = status.value if status else None
 
-        docs_data = self.sales_repo.get_all_sales_documents(customer_id=customer_id, document_type=doc_type_value, status=status_value)
+        docs_data = self.sales_repo.get_all_sales_documents(
+            customer_id=customer_id,
+            document_type=doc_type_value,
+            status=status_value,
+            is_active=is_active,
+        )
         result_list = []
         for doc_data in docs_data:
             status_enum = None
-            if doc_data.get('status'):
+            if doc_data.get("status"):
                 try:
-                    status_enum = SalesDocumentStatus(doc_data['status'])
+                    status_enum = SalesDocumentStatus(doc_data["status"])
                 except ValueError:
-                    logger.warning("Invalid sales status '%s' in DB for doc ID %s", doc_data['status'], doc_data['id'])
+                    logger.warning(
+                        "Invalid sales status '%s' in DB for doc ID %s",
+                        doc_data["status"],
+                        doc_data["id"],
+                    )
 
             doc_type_enum = None
-            if doc_data.get('document_type'):
+            if doc_data.get("document_type"):
                 try:
-                    doc_type_enum = SalesDocumentType(doc_data['document_type'])
+                    doc_type_enum = SalesDocumentType(doc_data["document_type"])
                 except ValueError:
-                    logger.warning("Invalid sales document type '%s' in DB for doc ID %s", doc_data['document_type'], doc_data['id'])
+                    logger.warning(
+                        "Invalid sales document type '%s' in DB for doc ID %s",
+                        doc_data["document_type"],
+                        doc_data["id"],
+                    )
 
-            result_list.append(SalesDocument(
-                doc_id=doc_data['id'],
-                document_number=doc_data['document_number'],
-                customer_id=doc_data['customer_id'],
-                document_type=doc_type_enum,
-                created_date=doc_data['created_date'],
-                expiry_date=doc_data.get('expiry_date'),
-                due_date=doc_data.get('due_date'),
-                status=status_enum,
-                notes=doc_data.get('notes'),
-                subtotal=doc_data.get('subtotal'),
-                taxes=doc_data.get('taxes'),
-                total_amount=doc_data.get('total_amount'),
-                related_quote_id=doc_data.get('related_quote_id')
-            ))
+            result_list.append(
+                SalesDocument(
+                    doc_id=doc_data["id"],
+                    document_number=doc_data["document_number"],
+                    customer_id=doc_data["customer_id"],
+                    document_type=doc_type_enum,
+                    created_date=doc_data["created_date"],
+                    expiry_date=doc_data.get("expiry_date"),
+                    due_date=doc_data.get("due_date"),
+                    status=status_enum,
+                    notes=doc_data.get("notes"),
+                    subtotal=doc_data.get("subtotal"),
+                    taxes=doc_data.get("taxes"),
+                    total_amount=doc_data.get("total_amount"),
+                    related_quote_id=doc_data.get("related_quote_id"),
+                    is_active=bool(doc_data.get("is_active", True)),
+                )
+            )
         return result_list
 
     def get_items_for_sales_document(self, doc_id: int) -> List[SalesDocumentItem]:
@@ -535,24 +566,19 @@ class SalesLogic:
         if not doc:
             raise ValueError(f"Sales document with ID {doc_id} not found.")
 
-        # Add any business logic checks here, e.g., cannot delete a PAID invoice.
-        # For now, allowing deletion if found.
-        # Note: DB ON DELETE CASCADE should handle items if configured on FK.
-        # If not, items must be deleted manually first.
-        # The sales_document_items table in database_setup.py does NOT have ON DELETE CASCADE.
-        # So, we must delete items first.
-
         items = self.get_items_for_sales_document(doc_id)
         if items:
-             # Check if document status allows item/document deletion
             deletable_doc_statuses = [
-                SalesDocumentStatus.QUOTE_DRAFT, SalesDocumentStatus.QUOTE_REJECTED, SalesDocumentStatus.QUOTE_EXPIRED,
-                SalesDocumentStatus.INVOICE_DRAFT, SalesDocumentStatus.INVOICE_VOID
+                SalesDocumentStatus.QUOTE_DRAFT,
+                SalesDocumentStatus.QUOTE_REJECTED,
+                SalesDocumentStatus.QUOTE_EXPIRED,
+                SalesDocumentStatus.INVOICE_DRAFT,
+                SalesDocumentStatus.INVOICE_VOID,
             ]
-            if doc.status not in deletable_doc_statuses :
-                 raise ValueError(f"Cannot delete document with status '{doc.status.value}' that has items. Consider voiding first.")
+            if doc.status not in deletable_doc_statuses:
+                raise ValueError(
+                    f"Cannot delete document with status '{doc.status.value}' that has items. Consider voiding first."
+                )
 
-            for item in items:
-                self.sales_repo.delete_sales_document_item(item.id) # Use the item's own ID
-
+        # Soft delete by marking inactive
         self.sales_repo.delete_sales_document(doc_id)

--- a/core/schema/purchase.py
+++ b/core/schema/purchase.py
@@ -10,6 +10,7 @@ def create_schema(cursor: sqlite3.Cursor) -> None:
             created_date TEXT NOT NULL,
             status TEXT NOT NULL,
             notes TEXT,
+            is_active BOOLEAN DEFAULT TRUE,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (vendor_id) REFERENCES accounts(id)

--- a/core/schema/sales.py
+++ b/core/schema/sales.py
@@ -17,6 +17,7 @@ def create_schema(cursor: sqlite3.Cursor) -> None:
             taxes REAL DEFAULT 0.0,
             total_amount REAL DEFAULT 0.0,
             related_quote_id INTEGER,
+            is_active BOOLEAN DEFAULT TRUE,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (customer_id) REFERENCES accounts(id),

--- a/shared/structs.py
+++ b/shared/structs.py
@@ -118,13 +118,23 @@ class SalesDocumentStatus(Enum):
     INVOICE_OVERDUE = "Invoice Overdue"
 
 class SalesDocument:
-    def __init__(self, doc_id=None, document_number: str = "", customer_id: int = None,
-                 document_type: SalesDocumentType = None,
-                 created_date: str = None, expiry_date: Optional[str] = None,  # For Quotes
-                 due_date: Optional[str] = None,  # For Invoices
-                 status: SalesDocumentStatus = None, notes: str = None,
-                 subtotal: Optional[float] = 0.0, taxes: Optional[float] = 0.0, total_amount: Optional[float] = 0.0,
-                 related_quote_id: Optional[int] = None):  # Link invoice to quote
+    def __init__(
+        self,
+        doc_id=None,
+        document_number: str = "",
+        customer_id: int = None,
+        document_type: SalesDocumentType = None,
+        created_date: str = None,
+        expiry_date: Optional[str] = None,  # For Quotes
+        due_date: Optional[str] = None,  # For Invoices
+        status: SalesDocumentStatus = None,
+        notes: str = None,
+        subtotal: Optional[float] = 0.0,
+        taxes: Optional[float] = 0.0,
+        total_amount: Optional[float] = 0.0,
+        related_quote_id: Optional[int] = None,
+        is_active: bool = True,
+    ):
         self.id = doc_id
         self.document_number = document_number
         self.customer_id = customer_id  # Changed from vendor_id
@@ -138,6 +148,7 @@ class SalesDocument:
         self.taxes = taxes
         self.total_amount = total_amount
         self.related_quote_id = related_quote_id
+        self.is_active = is_active
 
     def to_dict(self) -> dict:
         return {
@@ -154,6 +165,7 @@ class SalesDocument:
             "taxes": self.taxes,
             "total_amount": self.total_amount,
             "related_quote_id": self.related_quote_id,
+            "is_active": self.is_active,
         }
 
 class SalesDocumentItem:
@@ -199,14 +211,23 @@ class SalesDocumentItem:
 # --- End Sales Document Structures ---
 
 class PurchaseDocument:
-    def __init__(self, doc_id=None, document_number: str = "", vendor_id: int = None,
-                 created_date: str = None, status: PurchaseDocumentStatus = None, notes: str = None):
+    def __init__(
+        self,
+        doc_id=None,
+        document_number: str = "",
+        vendor_id: int = None,
+        created_date: str = None,
+        status: PurchaseDocumentStatus = None,
+        notes: str = None,
+        is_active: bool = True,
+    ):
         self.id = doc_id  # Using 'id' to match table column consistently
         self.document_number = document_number
         self.vendor_id = vendor_id
         self.created_date = created_date  # Should be ISO string
         self.status = status
         self.notes = notes
+        self.is_active = is_active
 
     def to_dict(self) -> dict:
         return {
@@ -216,6 +237,7 @@ class PurchaseDocument:
             "created_date": self.created_date,
             "status": self.status.value if self.status else None,
             "notes": self.notes,
+            "is_active": self.is_active,
         }
 
     def __str__(self) -> str:

--- a/tests/integration/test_purchase_system.py
+++ b/tests/integration/test_purchase_system.py
@@ -201,13 +201,14 @@ class TestPurchaseSystemIntegration(unittest.TestCase):
 
         self.purchase_logic.delete_purchase_document(rfq_to_delete.id)
 
-        # Check document is deleted
         deleted_doc_check = self.purchase_logic.get_purchase_document_details(rfq_to_delete.id)
-        self.assertIsNone(deleted_doc_check)
+        self.assertIsNotNone(deleted_doc_check)
+        self.assertFalse(deleted_doc_check.is_active)
 
-        # Check items are deleted (due to ON DELETE CASCADE)
-        items_after_delete = self.db_handler.get_items_for_document(rfq_to_delete.id) # Use DB direct to check
-        self.assertEqual(len(items_after_delete), 0)
+        items_after_delete = self.db_handler.get_items_for_document(
+            rfq_to_delete.id
+        )  # Use DB direct to check
+        self.assertEqual(len(items_after_delete), 2)
 
     def test_delete_specific_item(self):
         rfq = self.purchase_logic.create_rfq(vendor_id=self.vendor1_id)

--- a/tests/unit/test_sales_logic.py
+++ b/tests/unit/test_sales_logic.py
@@ -456,9 +456,7 @@ class TestSalesLogic(unittest.TestCase):
         ]
         self.mock_db_handler.get_items_for_sales_document.return_value = mock_items_list
         self.sales_logic.delete_sales_document(mock_doc_id)
-        self.assertEqual(self.mock_db_handler.delete_sales_document_item.call_count, 2)
-        self.mock_db_handler.delete_sales_document_item.assert_any_call(mock_item_id1)
-        self.mock_db_handler.delete_sales_document_item.assert_any_call(mock_item_id2)
+        self.mock_db_handler.delete_sales_document_item.assert_not_called()
         self.mock_db_handler.delete_sales_document.assert_called_once_with(mock_doc_id)
 
     def test_delete_sales_document_not_found(self):

--- a/tests/unit/test_structs.py
+++ b/tests/unit/test_structs.py
@@ -82,7 +82,7 @@ class TestPurchaseDocumentClass(unittest.TestCase):
         doc_dict = doc.to_dict()
         expected_dict = {
             "id": 1, "document_number": "P00001", "vendor_id": 5,
-            "created_date": now_iso, "status": "Quoted", "notes": "Quoted notes"
+            "created_date": now_iso, "status": "Quoted", "notes": "Quoted notes", "is_active": True
         }
         self.assertEqual(doc_dict, expected_dict)
 


### PR DESCRIPTION
## Summary
- support soft delete for purchase and sales documents with new `is_active` flag
- expose "Show Inactive" filters in purchase and sales document tabs
- adjust tests for soft delete behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e2dfd270083319c911452626a4ee9