### PR TITLE
feat: support line item notes

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -809,7 +809,7 @@ class DatabaseHandler:
 # --- Sales Document Item CRUD Methods ---
     def add_sales_document_item(self, sales_doc_id: int, product_id: int, product_description: str,
                                 quantity: float, unit_price: float, discount_percentage: float = 0.0,
-                                line_total: float = None) -> int:
+                                line_total: float = None, note: str | None = None) -> int:
         """Adds a new item to a sales document."""
         # Calculate line_total if not provided
         if line_total is None:
@@ -818,9 +818,9 @@ class DatabaseHandler:
 
         self.cursor.execute("""
             INSERT INTO sales_document_items (sales_document_id, product_id, product_description,
-                                              quantity, unit_price, discount_percentage, line_total)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
-        """, (sales_doc_id, product_id, product_description, quantity, unit_price, discount_percentage, line_total))
+                                              quantity, unit_price, discount_percentage, line_total, note)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """, (sales_doc_id, product_id, product_description, quantity, unit_price, discount_percentage, line_total, note))
         self.conn.commit()
         return self.cursor.lastrowid
 
@@ -1081,12 +1081,12 @@ class DatabaseHandler:
         self.conn.commit()
 
 # Purchase Document Item related methods
-    def add_purchase_document_item(self, doc_id: int, product_description: str, quantity: float, product_id: int = None, unit_price: float = None, total_price: float = None) -> int:
+    def add_purchase_document_item(self, doc_id: int, product_description: str, quantity: float, product_id: int = None, unit_price: float = None, total_price: float = None, note: str | None = None) -> int:
         """Adds a new item to a purchase document and returns its ID."""
         self.cursor.execute("""
-            INSERT INTO purchase_document_items (purchase_document_id, product_description, quantity, product_id, unit_price, total_price)
-            VALUES (?, ?, ?, ?, ?, ?)
-        """, (doc_id, product_description, quantity, product_id, unit_price, total_price))
+            INSERT INTO purchase_document_items (purchase_document_id, product_description, quantity, product_id, unit_price, total_price, note)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        """, (doc_id, product_description, quantity, product_id, unit_price, total_price, note))
         self.conn.commit()
         return self.cursor.lastrowid
 
@@ -1096,13 +1096,13 @@ class DatabaseHandler:
         columns = [desc[0] for desc in self.cursor.description]
         return [dict(zip(columns, row)) for row in self.cursor.fetchall()]
 
-    def update_purchase_document_item(self, item_id: int, product_description: str, quantity: float, product_id: int = None, unit_price: float = None, total_price: float = None):
+    def update_purchase_document_item(self, item_id: int, product_description: str, quantity: float, product_id: int = None, unit_price: float = None, total_price: float = None, note: str | None = None):
         """Updates an existing purchase document item."""
         self.cursor.execute("""
             UPDATE purchase_document_items
-            SET product_description = ?, quantity = ?, product_id = ?, unit_price = ?, total_price = ?
+            SET product_description = ?, quantity = ?, product_id = ?, unit_price = ?, total_price = ?, note = ?
             WHERE id = ?
-        """, (product_description, quantity, product_id, unit_price, total_price, item_id))
+        """, (product_description, quantity, product_id, unit_price, total_price, note, item_id))
         self.conn.commit()
 
     def delete_purchase_document_item(self, item_id: int):

--- a/core/invoice_generator.py
+++ b/core/invoice_generator.py
@@ -194,11 +194,11 @@ def generate_invoice_pdf(sales_document_id: int, output_path: str = None):
                     desc_text = "\n".join(
                         filter(
                             None,
-                            [product_info.get("name"), product_info.get("description")],
+                            [product_info.get("name"), product_info.get("description"), item.note],
                         )
                     )
                 else:
-                    desc_text = item.product_description or ""
+                    desc_text = "\n".join(filter(None, [item.product_description, item.note]))
                 pdf.multi_cell(desc_col, line_height, desc_text, 1, "L")
                 end_y_desc = pdf.get_y()
 

--- a/core/purchase_logic.py
+++ b/core/purchase_logic.py
@@ -96,7 +96,8 @@ class PurchaseLogic:
     def add_item_to_document(self, doc_id: int, product_id: int, quantity: float,
                              product_description_override: Optional[str] = None,
                              unit_price: Optional[float] = None,
-                             total_price: Optional[float] = None) -> Optional[PurchaseDocumentItem]:
+                             total_price: Optional[float] = None,
+                             note: str | None = None) -> Optional[PurchaseDocumentItem]:
         """Adds an item (linked to a product) to an RFQ or PO."""
         doc = self.get_purchase_document_details(doc_id)
         if not doc:
@@ -133,7 +134,8 @@ class PurchaseLogic:
             product_description=final_description,
             quantity=quantity,
             unit_price=unit_price,
-            total_price=total_price
+            total_price=total_price,
+            note=note
         )
         if new_item_id:
             return self.get_purchase_document_item_details(new_item_id)
@@ -141,7 +143,8 @@ class PurchaseLogic:
 
     def update_document_item(self, item_id: int, product_id: int, quantity: float,
                              unit_price: Optional[float],
-                             product_description_override: Optional[str] = None) -> Optional[PurchaseDocumentItem]:
+                             product_description_override: Optional[str] = None,
+                             note: str | None = None) -> Optional[PurchaseDocumentItem]:
         """Updates an existing document item. If unit_price is provided for an RFQ item, status may change to Quoted."""
         item_to_update = self.get_purchase_document_item_details(item_id)
         if not item_to_update:
@@ -167,6 +170,7 @@ class PurchaseLogic:
         item_to_update.product_description = final_description
         item_to_update.quantity = quantity
         item_to_update.unit_price = unit_price
+        item_to_update.note = note if note is not None else item_to_update.note
         item_to_update.calculate_total_price()
 
         self.purchase_repo.update_purchase_document_item(
@@ -175,7 +179,8 @@ class PurchaseLogic:
             product_description=item_to_update.product_description,
             quantity=item_to_update.quantity,
             unit_price=item_to_update.unit_price,
-            total_price=item_to_update.total_price
+            total_price=item_to_update.total_price,
+            note=item_to_update.note
         )
 
         if unit_price is not None:
@@ -350,7 +355,8 @@ class PurchaseLogic:
                 product_description=item_data['product_description'],
                 quantity=item_data['quantity'],
                 unit_price=item_data.get('unit_price'),
-                total_price=item_data.get('total_price')
+                total_price=item_data.get('total_price'),
+                note=item_data.get('note')
             ))
         return result_list
 
@@ -364,7 +370,8 @@ class PurchaseLogic:
                 product_description=item_data['product_description'],
                 quantity=item_data['quantity'],
                 unit_price=item_data.get('unit_price'),
-                total_price=item_data.get('total_price')
+                total_price=item_data.get('total_price'),
+                note=item_data.get('note')
             )
         return None
 

--- a/core/purchase_order_generator.py
+++ b/core/purchase_order_generator.py
@@ -190,7 +190,8 @@ def generate_po_pdf(purchase_document_id: int, output_path: str = None):
                 # Handle multi-line descriptions
                 start_x = pdf.get_x()
                 start_y = pdf.get_y()
-                pdf.multi_cell(desc_col, line_height, item.product_description or "", 1, "L")
+                desc_text = "\n".join(filter(None, [item.product_description, item.note]))
+                pdf.multi_cell(desc_col, line_height, desc_text, 1, "L")
                 end_y_desc = pdf.get_y()
 
                 pdf.set_xy(start_x + desc_col, start_y) # Reset X position for next cells in the row

--- a/core/quote_generator.py
+++ b/core/quote_generator.py
@@ -194,11 +194,11 @@ def generate_quote_pdf(sales_document_id: int, output_path: str = None):
                     desc_text = "\n".join(
                         filter(
                             None,
-                            [product_info.get("name"), product_info.get("description")],
+                            [product_info.get("name"), product_info.get("description"), item.note],
                         )
                     )
                 else:
-                    desc_text = item.product_description or ""
+                    desc_text = "\n".join(filter(None, [item.product_description, item.note]))
                 pdf.multi_cell(desc_col, line_height, desc_text, 1, "L")
                 end_y_desc = pdf.get_y()
 

--- a/core/sales_logic.py
+++ b/core/sales_logic.py
@@ -102,7 +102,8 @@ class SalesLogic:
     def add_item_to_sales_document(self, doc_id: int, product_id: int, quantity: float,
                                    product_description_override: Optional[str] = None,
                                    unit_price_override: Optional[float] = None, # This would be the sale price
-                                   discount_percentage: Optional[float] = 0.0
+                                   discount_percentage: Optional[float] = 0.0,
+                                   note: str | None = None
                                    ) -> Optional[SalesDocumentItem]:
         """Adds an item to a Quote or Invoice."""
         doc = self.get_sales_document_details(doc_id)
@@ -165,7 +166,8 @@ class SalesLogic:
             quantity=quantity,
             unit_price=final_unit_price,
             discount_percentage=effective_discount,
-            line_total=line_total
+            line_total=line_total,
+            note=note
         )
         if new_item_id:
             self._recalculate_sales_document_totals(doc_id)
@@ -175,7 +177,8 @@ class SalesLogic:
     def update_sales_document_item(self, item_id: int, product_id: int, quantity: float,
                                    unit_price_override: Optional[float], # Sale price
                                    discount_percentage: Optional[float] = 0.0,
-                                   product_description_override: Optional[str] = None
+                                   product_description_override: Optional[str] = None,
+                                   note: str | None = None
                                    ) -> Optional[SalesDocumentItem]:
         item_to_update = self.get_sales_document_item_details(item_id)
         if not item_to_update:
@@ -235,8 +238,10 @@ class SalesLogic:
             "quantity": quantity,
             "unit_price": final_unit_price,
             "discount_percentage": effective_discount,
-            "line_total": new_line_total
+            "line_total": new_line_total,
         }
+        if note is not None:
+            updates["note"] = note
         self.sales_repo.update_sales_document_item(item_id, updates)
         self._recalculate_sales_document_totals(doc.id)
         return self.get_sales_document_item_details(item_id)
@@ -512,7 +517,8 @@ class SalesLogic:
                 quantity=item_data['quantity'],
                 unit_price=item_data.get('unit_price'),
                 discount_percentage=item_data.get('discount_percentage'),
-                line_total=item_data.get('line_total')
+                line_total=item_data.get('line_total'),
+                note=item_data.get('note')
             ))
         return result_list
 
@@ -527,7 +533,8 @@ class SalesLogic:
                 quantity=item_data['quantity'],
                 unit_price=item_data.get('unit_price'),
                 discount_percentage=item_data.get('discount_percentage'),
-                line_total=item_data.get('line_total')
+                line_total=item_data.get('line_total'),
+                note=item_data.get('note')
             )
         return None
 

--- a/core/schema/purchase.py
+++ b/core/schema/purchase.py
@@ -26,6 +26,7 @@ def create_schema(cursor: sqlite3.Cursor) -> None:
             quantity REAL NOT NULL,
             unit_price REAL,
             total_price REAL,
+            note TEXT,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (purchase_document_id) REFERENCES purchase_documents(id),

--- a/core/schema/sales.py
+++ b/core/schema/sales.py
@@ -35,6 +35,7 @@ def create_schema(cursor: sqlite3.Cursor) -> None:
             unit_price REAL NOT NULL,
             discount_percentage REAL DEFAULT 0.0,
             line_total REAL NOT NULL,
+            note TEXT,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (sales_document_id) REFERENCES sales_documents(id),

--- a/shared/structs.py
+++ b/shared/structs.py
@@ -173,7 +173,8 @@ class SalesDocumentItem:
                  product_description: str = "", quantity: float = 0.0,
                  unit_price: float = None,  # This would be sale_price from Product
                  discount_percentage: Optional[float] = 0.0,
-                 line_total: float = None):  # quantity * unit_price * (1 - discount_percentage/100)
+                 line_total: float = None,
+                 note: str | None = None):  # quantity * unit_price * (1 - discount_percentage/100)
         self.id = item_id
         self.sales_document_id = sales_document_id
         self.product_id = product_id
@@ -182,6 +183,7 @@ class SalesDocumentItem:
         self.unit_price = unit_price  # Sale price
         self.discount_percentage = discount_percentage if discount_percentage is not None else 0.0
         self.line_total = line_total  # Calculated
+        self.note = note
 
     def calculate_line_total(self):
         """Calculates line total based on quantity, unit_price, and discount."""
@@ -202,6 +204,7 @@ class SalesDocumentItem:
             "unit_price": self.unit_price,
             "discount_percentage": self.discount_percentage,
             "line_total": self.line_total,
+            "note": self.note,
         }
 
     def __str__(self) -> str:
@@ -269,7 +272,8 @@ class CompanyInformation:
 class PurchaseDocumentItem:
     def __init__(self, item_id=None, purchase_document_id: int = None, product_id: Optional[int] = None,
                  product_description: str = "", quantity: float = 0.0,
-                 unit_price: float = None, total_price: float = None):
+                 unit_price: float = None, total_price: float = None,
+                 note: str | None = None):
         self.id = item_id  # Using 'id'
         self.purchase_document_id = purchase_document_id
         self.product_id = product_id
@@ -277,6 +281,7 @@ class PurchaseDocumentItem:
         self.quantity = quantity
         self.unit_price = unit_price
         self.total_price = total_price  # Should be calculated quantity * unit_price if unit_price is known
+        self.note = note
 
     def calculate_total_price(self):
         """Calculates total price if quantity and unit_price are set."""
@@ -295,6 +300,7 @@ class PurchaseDocumentItem:
             "quantity": self.quantity,
             "unit_price": self.unit_price,
             "total_price": self.total_price,
+            "note": self.note,
         }
 
     def __str__(self) -> str:

--- a/tests/unit/test_purchase_logic.py
+++ b/tests/unit/test_purchase_logic.py
@@ -102,7 +102,7 @@ class TestPurchaseLogic(unittest.TestCase):
         self.mock_db_handler.get_purchase_document_item_by_id.return_value = {
             "id": 50, "purchase_document_id": doc_id, "product_id": product_id_to_add,
             "product_description": mock_product_name, # Description from fetched product
-            "quantity": 2.0, "unit_price": None, "total_price": None
+            "quantity": 2.0, "unit_price": None, "total_price": None, "note": None
         }
 
         item = self.purchase_logic.add_item_to_document(doc_id, product_id=product_id_to_add, quantity=2.0)
@@ -114,7 +114,7 @@ class TestPurchaseLogic(unittest.TestCase):
         self.mock_db_handler.add_purchase_document_item.assert_called_with(
             doc_id=doc_id, product_id=product_id_to_add,
             product_description=mock_product_name, quantity=2.0,
-            unit_price=None, total_price=None
+            unit_price=None, total_price=None, note=None
         )
 
     def test_add_item_to_document_doc_not_found(self):
@@ -150,6 +150,9 @@ class TestPurchaseLogic(unittest.TestCase):
             "product_id": 101,
             "product_description": "Item",
             "quantity": 1.0,
+            "unit_price": None,
+            "total_price": None,
+            "note": None,
         }
         # Mock parent document with non-editable status
         self.mock_db_handler.get_purchase_document_by_id.return_value = {
@@ -178,7 +181,7 @@ class TestPurchaseLogic(unittest.TestCase):
         # Mock return for get_purchase_document_item_details
         self.mock_db_handler.get_purchase_document_item_by_id.return_value = {
             "id": 1, "purchase_document_id": 1, "product_id":101,
-            "product_description": "Test", "quantity": 1
+            "product_description": "Test", "quantity": 1, "unit_price": None, "total_price": None, "note": None
         }
         with self.assertRaisesRegex(ValueError, "Unit price cannot be negative if provided."): # Adjusted message
             self.purchase_logic.update_document_item(item_id=1, product_id=101, quantity=1, unit_price=-5.0)
@@ -210,6 +213,7 @@ class TestPurchaseLogic(unittest.TestCase):
                 "quantity": 5,
                 "unit_price": None,
                 "total_price": None,
+                "note": None,
             }
         ]
 
@@ -387,8 +391,8 @@ class TestPurchaseLogic(unittest.TestCase):
     def test_get_items_for_document_logic(self):
         doc_id = 8
         mock_items_data = [
-            {"id": 1, "purchase_document_id": doc_id, "product_description": "Item A", "quantity": 1.0},
-            {"id": 2, "purchase_document_id": doc_id, "product_description": "Item B", "quantity": 2.0}
+            {"id": 1, "purchase_document_id": doc_id, "product_id": None, "product_description": "Item A", "quantity": 1.0, "unit_price": None, "total_price": None, "note": None},
+            {"id": 2, "purchase_document_id": doc_id, "product_id": None, "product_description": "Item B", "quantity": 2.0, "unit_price": None, "total_price": None, "note": None}
         ]
         self.mock_db_handler.get_items_for_document.return_value = mock_items_data
 
@@ -405,7 +409,7 @@ class TestPurchaseLogic(unittest.TestCase):
         original_item_data = {
             "id": item_id, "purchase_document_id": doc_id, "product_id": 101,
             "product_description": "Test Product", "quantity": 2.0,
-            "unit_price": None, "total_price": None
+            "unit_price": None, "total_price": None, "note": None
         }
         # Mock for initial get_purchase_document_item_details
         self.mock_db_handler.get_purchase_document_item_by_id.return_value = original_item_data
@@ -419,7 +423,7 @@ class TestPurchaseLogic(unittest.TestCase):
         updated_item_data_after_save = {
             "id": item_id, "purchase_document_id": doc_id, "product_id": 101,
             "product_description": "Test Product", "quantity": 2.0,
-            "unit_price": 10.0, "total_price": 20.0
+            "unit_price": 10.0, "total_price": 20.0, "note": None
         }
         # get_purchase_document_by_id will be called to check status, then potentially to re-fetch doc for return (not strictly needed for this test focus)
         # get_purchase_document_item_by_id will be called to fetch item, then again to return the updated item.
@@ -442,7 +446,7 @@ class TestPurchaseLogic(unittest.TestCase):
         self.assertEqual(updated_item.total_price, 20.0)
         self.mock_db_handler.update_purchase_document_item.assert_called_with(
             item_id=item_id, product_id=101, product_description="Test Product",
-            quantity=2.0, unit_price=10.0, total_price=20.0
+            quantity=2.0, unit_price=10.0, total_price=20.0, note=None
         )
         # Verify status update for parent document
         self.mock_db_handler.update_purchase_document_status.assert_called_with(doc_id, PurchaseDocumentStatus.QUOTED.value)
@@ -453,7 +457,7 @@ class TestPurchaseLogic(unittest.TestCase):
         original_item_data = {
             "id": item_id, "purchase_document_id": doc_id, "product_id": 102,
             "product_description": "Another Product", "quantity": 5.0,
-            "unit_price": 4.0, "total_price": 20.0 # Already quoted
+            "unit_price": 4.0, "total_price": 20.0, "note": None # Already quoted
         }
         self.mock_db_handler.get_purchase_document_item_by_id.return_value = original_item_data
 
@@ -464,7 +468,7 @@ class TestPurchaseLogic(unittest.TestCase):
         updated_item_data_after_save = {
             "id": item_id, "purchase_document_id": doc_id, "product_id": 102,
             "product_description": "Another Product", "quantity": 7.0,
-            "unit_price": 4.0, "total_price": 28.0
+            "unit_price": 4.0, "total_price": 28.0, "note": None
         }
         self.mock_db_handler.get_purchase_document_by_id.return_value = parent_doc_data_quoted
 
@@ -483,7 +487,7 @@ class TestPurchaseLogic(unittest.TestCase):
         self.assertEqual(updated_item.total_price, 28.0)
         self.mock_db_handler.update_purchase_document_item.assert_called_with(
             item_id=item_id, product_id=102, product_description="Another Product",
-            quantity=7.0, unit_price=4.0, total_price=28.0
+            quantity=7.0, unit_price=4.0, total_price=28.0, note=None
         )
         self.mock_db_handler.update_purchase_document_status.assert_not_called() # Status should not change
 

--- a/tests/unit/test_sales_logic.py
+++ b/tests/unit/test_sales_logic.py
@@ -109,7 +109,7 @@ class TestSalesLogic(unittest.TestCase):
             "id": new_item_id, "sales_document_id": mock_doc_id, "product_id": mock_product_id,
             "product_description": "Test Product", "quantity": mock_quantity,
             "unit_price": 100.00, "discount_percentage": mock_discount,
-            "line_total": 180.00
+            "line_total": 180.00, "note": None
         }
         self.mock_db_handler.get_sales_document_item_by_id.return_value = mock_item_dict
         self.mock_db_handler.get_items_for_sales_document.return_value = [mock_item_dict.copy()]
@@ -177,7 +177,7 @@ class TestSalesLogic(unittest.TestCase):
             "id": new_item_id, "sales_document_id": mock_doc_id, "product_id": mock_product_id,
             "product_description": "Test Product", "quantity": mock_quantity,
             "unit_price": 100.00, "discount_percentage": mock_discount,
-            "line_total": 180.00
+            "line_total": 180.00, "note": None
         }
         self.mock_db_handler.get_sales_document_item_by_id.return_value = mock_item_dict
         self.mock_db_handler.get_items_for_sales_document.return_value = [mock_item_dict.copy()]
@@ -227,13 +227,13 @@ class TestSalesLogic(unittest.TestCase):
         initial_item_data = {
             "id": mock_item_id, "sales_document_id": mock_doc_id, "product_id": 10,
             "product_description": "Old Product Name", "quantity": 1.0,
-            "unit_price": 100.00, "discount_percentage": 0.0, "line_total": 100.00
+            "unit_price": 100.00, "discount_percentage": 0.0, "line_total": 100.00, "note": None
         }
         updated_item_data = {
             "id": mock_item_id, "sales_document_id": mock_doc_id, "product_id": mock_product_id,
             "product_description": "New Product Name", "quantity": new_quantity,
             "unit_price": new_unit_price, "discount_percentage": new_discount,
-            "line_total": new_quantity * new_unit_price * (1 - new_discount / 100.0)
+            "line_total": new_quantity * new_unit_price * (1 - new_discount / 100.0), "note": None
         }
 
         self.mock_db_handler.get_sales_document_item_by_id.side_effect = [
@@ -262,7 +262,7 @@ class TestSalesLogic(unittest.TestCase):
         self.mock_db_handler.get_sales_document_item_by_id.return_value = {
             "id": mock_item_id, "sales_document_id": mock_doc_id, "product_id": 10,
             "product_description": "Any Desc", "quantity": 1.0, "unit_price": 100.00,
-            "discount_percentage": 0.0, "line_total": 100.00
+            "discount_percentage": 0.0, "line_total": 100.00, "note": None
         }
         self.mock_db_handler.get_sales_document_by_id.return_value = {"id": mock_doc_id, "status": SalesDocumentStatus.INVOICE_PAID.value, "document_type":SalesDocumentType.INVOICE.value, "customer_id":1, "document_number":"I", "created_date":"d","subtotal":0,"taxes":0,"total_amount":0}
         self.mock_db_handler.get_product_details.return_value = {"product_id":1, "name":"P", "sale_price":10}
@@ -309,6 +309,7 @@ class TestSalesLogic(unittest.TestCase):
             "unit_price": 100.0,
             "discount_percentage": 0.0,
             "line_total": 500.0,
+            "note": None,
         }
         self.mock_db_handler.get_sales_document_by_id.side_effect = [
             mock_quote_data,
@@ -343,7 +344,7 @@ class TestSalesLogic(unittest.TestCase):
         mock_so_id = 1
         mock_customer_id = 5
         mock_so_data = {"id": mock_so_id, "document_number": "S00000", "customer_id": mock_customer_id, "document_type": SalesDocumentType.SALES_ORDER.value, "created_date": "date", "status": SalesDocumentStatus.SO_FULFILLED.value, "notes": "N", "subtotal": 200.0, "taxes": 20.0, "total_amount": 220.0}
-        mock_so_item_data = [{"id": 10, "sales_document_id": mock_so_id, "product_id": 100, "product_description": "Item 1", "quantity": 2.0, "unit_price": 100.0, "discount_percentage": 0.0, "line_total": 200.0}]
+        mock_so_item_data = [{"id": 10, "sales_document_id": mock_so_id, "product_id": 100, "product_description": "Item 1", "quantity": 2.0, "unit_price": 100.0, "discount_percentage": 0.0, "line_total": 200.0, "note": None}]
         new_invoice_id = 2
 
         self.mock_db_handler.get_sales_document_by_id.side_effect = [mock_so_data, {"id": new_invoice_id, "document_number": "S00001", "customer_id": mock_customer_id, "document_type": SalesDocumentType.INVOICE.value, "status": SalesDocumentStatus.INVOICE_DRAFT.value, "related_quote_id":mock_so_id, "total_amount":220.0, "created_date":"d"}]
@@ -409,7 +410,7 @@ class TestSalesLogic(unittest.TestCase):
         self.mock_db_handler.get_sales_document_item_by_id.return_value = {
             "id": mock_item_id, "sales_document_id": mock_doc_id, "product_id": 1,
             "product_description": "Desc", "quantity": 1.0, "unit_price": 50.0,
-            "discount_percentage": 0.0, "line_total": 50.0
+            "discount_percentage": 0.0, "line_total": 50.0, "note": None
         }
         self.mock_db_handler.get_sales_document_by_id.return_value = {"id": mock_doc_id, "status": SalesDocumentStatus.QUOTE_DRAFT.value, "document_type": SalesDocumentType.QUOTE.value, "customer_id":1, "document_number":"Q", "created_date":"d", "subtotal":100,"taxes":0,"total_amount":100}
         self.mock_db_handler.get_items_for_sales_document.return_value = [] # After deletion
@@ -431,7 +432,7 @@ class TestSalesLogic(unittest.TestCase):
         self.mock_db_handler.get_sales_document_item_by_id.return_value = {
             "id": mock_item_id, "sales_document_id": mock_doc_id, "product_id": 1,
             "product_description": "Desc", "quantity": 1.0, "unit_price": 50.0,
-            "discount_percentage": 0.0, "line_total": 50.0
+            "discount_percentage": 0.0, "line_total": 50.0, "note": None
         }
         self.mock_db_handler.get_sales_document_by_id.return_value = {"id": mock_doc_id, "status": SalesDocumentStatus.INVOICE_SENT.value, "document_type":SalesDocumentType.INVOICE.value, "customer_id":1, "document_number":"I", "created_date":"d", "subtotal":0,"taxes":0,"total_amount":0}
         with self.assertRaisesRegex(ValueError, "Items cannot be deleted from a document with status 'Invoice Sent'."):
@@ -451,8 +452,8 @@ class TestSalesLogic(unittest.TestCase):
         mock_item_id2 = 11
         self.mock_db_handler.get_sales_document_by_id.return_value = {"id": mock_doc_id, "status": SalesDocumentStatus.QUOTE_DRAFT.value, "document_type":SalesDocumentType.QUOTE.value, "customer_id":1, "document_number":"Q", "created_date":"d", "subtotal":0,"taxes":0,"total_amount":0}
         mock_items_list = [
-            {"id": mock_item_id1, "sales_document_id": mock_doc_id, "product_id": 1, "product_description": "Item 1", "quantity": 1, "unit_price": 10, "discount_percentage": 0, "line_total": 10},
-            {"id": mock_item_id2, "sales_document_id": mock_doc_id, "product_id": 2, "product_description": "Item 2", "quantity": 2, "unit_price": 20, "discount_percentage": 0, "line_total": 40}
+            {"id": mock_item_id1, "sales_document_id": mock_doc_id, "product_id": 1, "product_description": "Item 1", "quantity": 1, "unit_price": 10, "discount_percentage": 0, "line_total": 10, "note": None},
+            {"id": mock_item_id2, "sales_document_id": mock_doc_id, "product_id": 2, "product_description": "Item 2", "quantity": 2, "unit_price": 20, "discount_percentage": 0, "line_total": 40, "note": None}
         ]
         self.mock_db_handler.get_items_for_sales_document.return_value = mock_items_list
         self.sales_logic.delete_sales_document(mock_doc_id)
@@ -468,7 +469,7 @@ class TestSalesLogic(unittest.TestCase):
         mock_doc_id = 1
         self.mock_db_handler.get_sales_document_by_id.return_value = {"id": mock_doc_id, "status": SalesDocumentStatus.INVOICE_SENT.value, "document_type":SalesDocumentType.INVOICE.value, "customer_id":1, "document_number":"I", "created_date":"d", "subtotal":0,"taxes":0,"total_amount":0}
         self.mock_db_handler.get_items_for_sales_document.return_value = [ # Ensure items have all keys
-            {"id": 10, "sales_document_id": mock_doc_id, "product_id": 1, "product_description": "Item 1", "quantity": 1, "unit_price": 10, "discount_percentage": 0, "line_total": 10}
+            {"id": 10, "sales_document_id": mock_doc_id, "product_id": 1, "product_description": "Item 1", "quantity": 1, "unit_price": 10, "discount_percentage": 0, "line_total": 10, "note": None}
         ]
         with self.assertRaisesRegex(ValueError, "Cannot delete document with status 'Invoice Sent' that has items. Consider voiding first."):
             self.sales_logic.delete_sales_document(mock_doc_id)

--- a/tests/unit/test_structs.py
+++ b/tests/unit/test_structs.py
@@ -100,16 +100,18 @@ class TestPurchaseDocumentItemClass(unittest.TestCase):
         self.assertEqual(item.quantity, 0.0)
         self.assertIsNone(item.unit_price)
         self.assertIsNone(item.total_price)
+        self.assertIsNone(item.note)
 
     def test_item_creation_with_values(self):
         item = PurchaseDocumentItem(item_id=100, purchase_document_id=1, product_description="Test Product",
-                                    quantity=10.5, unit_price=2.0, total_price=21.0)
+                                    quantity=10.5, unit_price=2.0, total_price=21.0, note="Sample")
         self.assertEqual(item.id, 100)
         self.assertEqual(item.purchase_document_id, 1)
         self.assertEqual(item.product_description, "Test Product")
         self.assertEqual(item.quantity, 10.5)
         self.assertEqual(item.unit_price, 2.0)
         self.assertEqual(item.total_price, 21.0)
+        self.assertEqual(item.note, "Sample")
 
     def test_item_calculate_total_price(self):
         item = PurchaseDocumentItem(quantity=5, unit_price=10.0)
@@ -134,7 +136,7 @@ class TestPurchaseDocumentItemClass(unittest.TestCase):
         expected_dict = {
             "id": 1, "purchase_document_id": 2, "product_id": None, # Added product_id
             "product_description": "Another Product",
-            "quantity": 3, "unit_price": 5.0, "total_price": 15.0
+            "quantity": 3, "unit_price": 5.0, "total_price": 15.0, "note": None
         }
         self.assertEqual(item_dict, expected_dict)
 

--- a/ui/purchase_documents/purchase_document_item_popup.py
+++ b/ui/purchase_documents/purchase_document_item_popup.py
@@ -16,7 +16,7 @@ class PurchaseDocumentItemPopup(tk.Toplevel):
         self.product_map = {} # To map product name to product_id
 
         self.title(f"{'Edit' if self.item_id else 'Add'} Line Item")
-        self.geometry("400x200") # Initial size, can adjust
+        self.geometry("400x240") # Initial size, can adjust
         self.resizable(False, False)
 
         self.grab_set() # Make it modal
@@ -61,6 +61,13 @@ class PurchaseDocumentItemPopup(tk.Toplevel):
         self.unit_price_entry.grid(row=row, column=1, padx=5, pady=(5,5), sticky=tk.E)
         row += 1
 
+        # Note
+        ttk.Label(frame, text="Note:").grid(row=row, column=0, padx=5, pady=(5,2), sticky=tk.W)
+        self.note_var = tk.StringVar()
+        self.note_entry = ttk.Entry(frame, width=47, textvariable=self.note_var)
+        self.note_entry.grid(row=row, column=1, padx=5, pady=(5,5), sticky=tk.EW)
+        row += 1
+
         # Total Price (Read-only display)
         self.total_price_label = ttk.Label(frame, text="Total Price:") # Define if not already
         self.total_price_label.grid(row=row, column=0, padx=5, pady=(5,2), sticky=tk.W)
@@ -70,7 +77,7 @@ class PurchaseDocumentItemPopup(tk.Toplevel):
         row += 1
 
         # Adjust popup geometry if new fields make it too cramped
-        self.geometry("400x250") # Increased height
+        self.geometry("400x300") # Increased height
 
         # --- Buttons ---
         button_frame = ttk.Frame(frame)
@@ -94,6 +101,7 @@ class PurchaseDocumentItemPopup(tk.Toplevel):
                  self.unit_price_var.set(f"{item_data.get('unit_price', 0.0):.2f}") # Format to 2 decimal places
             else:
                 self.unit_price_var.set("0.00")
+            self.note_var.set(item_data.get('note', ''))
             self._calculate_and_display_total_price() # Calculate on load if editing
         else: # New item
             self.quantity_var.set("1") # Default quantity for new item
@@ -134,6 +142,7 @@ class PurchaseDocumentItemPopup(tk.Toplevel):
                 else: # No product selected in combobox either
                     self.unit_price_var.set("0.00")
 
+            self.note_var.set(item_data.get('note', ''))
             self._calculate_and_display_total_price() # Ensure total is calculated with final values
         else: # New item (already handled mostly, but ensure _on_product_selected isn't called if not needed)
             if self.product_combobox.get() == "<Select Product>": # If default "<Select Product>" is set
@@ -218,6 +227,7 @@ class PurchaseDocumentItemPopup(tk.Toplevel):
             return
 
         unit_price_str = self.unit_price_var.get().strip()
+        note_str = self.note_var.get().strip()
 
         try:
             quantity = float(quantity_str)
@@ -256,7 +266,8 @@ class PurchaseDocumentItemPopup(tk.Toplevel):
                     quantity=quantity,
                     # product_description_override can be passed if needed
                     unit_price=unit_price, # Pass the parsed unit price
-                    total_price=current_total_price # Pass the calculated total price
+                    total_price=current_total_price, # Pass the calculated total price
+                    note=note_str or None
                 )
                 if new_item:
                     messagebox.showinfo("Success", "Item added successfully.", parent=self)
@@ -271,7 +282,8 @@ class PurchaseDocumentItemPopup(tk.Toplevel):
                     product_id=selected_product_id, # Assuming product can be changed, or keep original if not
                     # description will be fetched by logic based on product_id or use override
                     quantity=quantity,
-                    unit_price=unit_price
+                    unit_price=unit_price,
+                    note=note_str or None
                 )
                 if updated_item:
                     messagebox.showinfo("Success", "Item updated successfully.", parent=self)

--- a/ui/sales_documents/sales_document_item_popup.py
+++ b/ui/sales_documents/sales_document_item_popup.py
@@ -15,7 +15,7 @@ class SalesDocumentItemPopup(Toplevel): # Changed class name
         self.product_map = {}
 
         self.title(f"{'Edit' if self.item_id else 'Add'} Line Item")
-        self.geometry("450x300") # Adjusted size for discount field
+        self.geometry("450x340") # Adjusted size for discount and note fields
         self.resizable(False, False)
         self.grab_set()
         self.focus_set()
@@ -55,6 +55,13 @@ class SalesDocumentItemPopup(Toplevel): # Changed class name
         self.discount_var = tk.StringVar(value="0.0") # Default discount
         self.discount_entry = ttk.Entry(frame, width=15, textvariable=self.discount_var)
         self.discount_entry.grid(row=row, column=1, padx=5, pady=(5,5), sticky=tk.E)
+        row += 1
+
+        # Note
+        ttk.Label(frame, text="Note:").grid(row=row, column=0, padx=5, pady=(5,2), sticky=tk.W)
+        self.note_var = tk.StringVar()
+        self.note_entry = ttk.Entry(frame, width=47, textvariable=self.note_var)
+        self.note_entry.grid(row=row, column=1, padx=5, pady=(5,5), sticky=tk.EW)
         row += 1
 
         # Line Total (Read-only display)
@@ -100,6 +107,7 @@ class SalesDocumentItemPopup(Toplevel): # Changed class name
         self.quantity_var.set(str(item_data.get('quantity', '1')))
         self.unit_price_var.set(f"{item_data.get('unit_price', 0.0):.2f}")
         self.discount_var.set(f"{item_data.get('discount_percentage', 0.0):.1f}")
+        self.note_var.set(item_data.get('note', ''))
         # Line total will be recalculated by trace or explicitly
         self._calculate_and_display_line_total()
 
@@ -168,6 +176,7 @@ class SalesDocumentItemPopup(Toplevel): # Changed class name
         quantity_str = self.quantity_var.get().strip()
         unit_price_str = self.unit_price_var.get().strip()
         discount_str = self.discount_var.get().strip()
+        note_str = self.note_var.get().strip()
 
         if not selected_product_name or selected_product_name == "<Select Product>":
             messagebox.showerror("Validation Error", "Please select a product.", parent=self)
@@ -212,7 +221,8 @@ class SalesDocumentItemPopup(Toplevel): # Changed class name
                     quantity=quantity,
                     unit_price_override=unit_price, # Pass the UI entered price as override
                     discount_percentage=discount_percentage,
-                    product_description_override=final_product_description # Pass the fetched name/description
+                    product_description_override=final_product_description, # Pass the fetched name/description
+                    note=note_str or None
                 )
                 if new_item:
                     messagebox.showinfo("Success", "Item added successfully.", parent=self)
@@ -225,7 +235,8 @@ class SalesDocumentItemPopup(Toplevel): # Changed class name
                     quantity=quantity,
                     unit_price_override=unit_price,
                     discount_percentage=discount_percentage,
-                    product_description_override=final_product_description
+                    product_description_override=final_product_description,
+                    note=note_str or None
                 )
                 if updated_item:
                     messagebox.showinfo("Success", "Item updated successfully.", parent=self)


### PR DESCRIPTION
## Summary
- allow adding notes to sales and purchase document line items
- include line-item notes in add/edit popups and exported PDFs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e36567d8483318e9e640645d077b2