### PR TITLE
Add reference number to sales orders and require it for quote conversion

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -739,15 +739,16 @@ class DatabaseHandler:
 
 # --- Sales Document CRUD Methods ---
     def add_sales_document(self, doc_number: str, customer_id: int, document_type: str,
-                           created_date: str, status: str, expiry_date: str = None, due_date: str = None,
+                           created_date: str, status: str, reference_number: str = None,
+                           expiry_date: str = None, due_date: str = None,
                            notes: str = None, subtotal: float = 0.0, taxes: float = 0.0, total_amount: float = 0.0,
                            related_quote_id: int = None) -> int:
         """Adds a new sales document and returns its ID."""
         self.cursor.execute("""
             INSERT INTO sales_documents (document_number, customer_id, document_type, created_date, status,
-                                         expiry_date, due_date, notes, subtotal, taxes, total_amount, related_quote_id)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        """, (doc_number, customer_id, document_type, created_date, status, expiry_date, due_date,
+                                         reference_number, expiry_date, due_date, notes, subtotal, taxes, total_amount, related_quote_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """, (doc_number, customer_id, document_type, created_date, status, reference_number, expiry_date, due_date,
               notes, subtotal, taxes, total_amount, related_quote_id))
         self.conn.commit()
         return self.cursor.lastrowid

--- a/core/sales_logic.py
+++ b/core/sales_logic.py
@@ -47,8 +47,9 @@ class SalesLogic:
         self.inventory_service = inventory_service or InventoryService(
             inv_repo, self.product_repo
         )
-
-        self._db = self.account_repo.db if self.account_repo else None
+        # Expose the underlying database handler for legacy callers
+        self.db = db_handler
+        self._db = db_handler
 
     def _generate_sales_document_number(self, doc_type: SalesDocumentType) -> str:
         """Generates a unique sales document number in the format ``S#####``.

--- a/core/schema/sales.py
+++ b/core/schema/sales.py
@@ -12,6 +12,7 @@ def create_schema(cursor: sqlite3.Cursor) -> None:
             expiry_date TEXT,
             due_date TEXT,
             status TEXT NOT NULL,
+            reference_number TEXT,
             notes TEXT,
             subtotal REAL DEFAULT 0.0,
             taxes REAL DEFAULT 0.0,

--- a/shared/structs.py
+++ b/shared/structs.py
@@ -129,6 +129,7 @@ class SalesDocument:
         due_date: Optional[str] = None,  # For Invoices
         status: SalesDocumentStatus = None,
         notes: str = None,
+        reference_number: Optional[str] = None,
         subtotal: Optional[float] = 0.0,
         taxes: Optional[float] = 0.0,
         total_amount: Optional[float] = 0.0,
@@ -144,6 +145,7 @@ class SalesDocument:
         self.due_date = due_date
         self.status = status
         self.notes = notes
+        self.reference_number = reference_number
         self.subtotal = subtotal
         self.taxes = taxes
         self.total_amount = total_amount
@@ -161,6 +163,7 @@ class SalesDocument:
             "due_date": self.due_date,
             "status": self.status.value if self.status else None,
             "notes": self.notes,
+            "reference_number": self.reference_number,
             "subtotal": self.subtotal,
             "taxes": self.taxes,
             "total_amount": self.total_amount,

--- a/tests/integration/test_inventory_workflow.py
+++ b/tests/integration/test_inventory_workflow.py
@@ -43,7 +43,7 @@ class InventoryWorkflowIntegrationTest(unittest.TestCase):
         self.db.close()
 
     def test_full_inventory_cycle(self):
-        quote = self.sales_logic.create_quote(self.customer_id)
+        quote = self.sales_logic.create_quote(self.customer_id, reference_number="PO123")
         self.sales_logic.add_item_to_sales_document(
             quote.id, self.product_id, 10, unit_price_override=5.0
         )

--- a/tests/unit/test_sales_logic.py
+++ b/tests/unit/test_sales_logic.py
@@ -29,6 +29,9 @@ class TestSalesLogic(unittest.TestCase):
         self.mock_db_handler = MagicMock()
         self.sales_logic = SalesLogic(self.mock_db_handler)
 
+    def test_exposes_db_handler(self):
+        self.assertIs(self.sales_logic.db, self.mock_db_handler)
+
     def test_create_quote_success(self):
         mock_customer_id = 1
         mock_notes = "Test quote notes"


### PR DESCRIPTION
## Summary
- allow sales documents to store a customer reference number
- show "Reference #" in the sales document popup and persist it
- enforce that a quote must have a reference number before converting to a sales order

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e3cae2bac833192096de19d872b56