### PR TITLE
Add payment term management and account assignment

### DIFF
--- a/core/repositories.py
+++ b/core/repositories.py
@@ -59,8 +59,8 @@ class AccountRepository:
     def get_account_addresses(self, account_id):
         return self.db.get_account_addresses(account_id)
 
-    def add_account(self, name, phone, website, description, account_type, pricing_rule_id=None):
-        return self.db.add_account(name, phone, website, description, account_type, pricing_rule_id)
+    def add_account(self, name, phone, website, description, account_type, pricing_rule_id=None, payment_term_id=None):
+        return self.db.add_account(name, phone, website, description, account_type, pricing_rule_id, payment_term_id)
 
     def get_all_accounts(self):
         return self.db.get_all_accounts()
@@ -74,12 +74,34 @@ class AccountRepository:
     def get_account_details(self, account_id):
         return self.db.get_account_details(account_id)
 
-    def update_account(self, account_id, name, phone, website, description, account_type, pricing_rule_id=None):
-        self.db.update_account(account_id, name, phone, website, description, account_type, pricing_rule_id)
+    def update_account(self, account_id, name, phone, website, description, account_type, pricing_rule_id=None, payment_term_id=None):
+        self.db.update_account(account_id, name, phone, website, description, account_type, pricing_rule_id, payment_term_id)
 
     def clear_account_addresses(self, account_id):
         self.db.cursor.execute("DELETE FROM account_addresses WHERE account_id = ?", (account_id,))
         self.db.conn.commit()
+
+    # Payment terms
+    def add_payment_term(self, term_name, days=None):
+        return self.db.add_payment_term(term_name, days)
+
+    def get_payment_term(self, term_id):
+        return self.db.get_payment_term(term_id)
+
+    def get_all_payment_terms(self):
+        return self.db.get_all_payment_terms()
+
+    def update_payment_term(self, term_id, term_name, days=None):
+        self.db.update_payment_term(term_id, term_name, days)
+
+    def delete_payment_term(self, term_id):
+        self.db.delete_payment_term(term_id)
+
+    def assign_payment_term_to_account(self, account_id, term_id):
+        self.db.assign_payment_term_to_account(account_id, term_id)
+
+    def remove_payment_term_from_account(self, account_id):
+        self.db.remove_payment_term_from_account(account_id)
 
 
 class ProductRepository:

--- a/core/schema/accounts.py
+++ b/core/schema/accounts.py
@@ -12,9 +12,11 @@ def create_schema(cursor: sqlite3.Cursor) -> None:
             website TEXT,
             description TEXT,
             pricing_rule_id INTEGER,
+            payment_term_id INTEGER,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            FOREIGN KEY (pricing_rule_id) REFERENCES pricing_rules (rule_id) ON DELETE SET NULL
+            FOREIGN KEY (pricing_rule_id) REFERENCES pricing_rules (rule_id) ON DELETE SET NULL,
+            FOREIGN KEY (payment_term_id) REFERENCES payment_terms (term_id) ON DELETE SET NULL
         )
     """)
 

--- a/core/schema/common.py
+++ b/core/schema/common.py
@@ -23,3 +23,12 @@ def create_schema(cursor: sqlite3.Cursor) -> None:
             CONSTRAINT either_markup_or_fixed CHECK (markup_percentage IS NOT NULL OR fixed_markup IS NOT NULL)
         )
     """)
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS payment_terms (
+            term_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            term_name TEXT UNIQUE NOT NULL,
+            days INTEGER,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """)

--- a/shared/account_structs.py
+++ b/shared/account_structs.py
@@ -47,6 +47,7 @@ class Account:
     description: str = ""
     account_type: Optional[AccountType] = None
     pricing_rule_id: Optional[int] = None
+    payment_term_id: Optional[int] = None
 
     def __str__(self) -> str:
         addresses_str = "\n".join([str(addr) for addr in self.addresses])
@@ -58,7 +59,8 @@ class Account:
             f"Website: {self.website}\n"
             f"Description: {self.description}\n"
             f"Account Type: {self.account_type.value if self.account_type else 'N/A'}\n"
-            f"Pricing Rule ID: {self.pricing_rule_id}"
+            f"Pricing Rule ID: {self.pricing_rule_id}\n"
+            f"Payment Term ID: {self.payment_term_id}"
         )
 
     def to_dict(self) -> dict:
@@ -72,16 +74,21 @@ class Account:
             "description": self.description,
             "account_type": self.account_type.value if self.account_type else None,
             "pricing_rule_id": self.pricing_rule_id,
+            "payment_term_id": self.payment_term_id,
         }
 
     @classmethod
     def from_row(cls, row: tuple) -> "Account":
         """Creates an Account object from a database row."""
-        if len(row) == 6:
+        if len(row) == 7:
+            account_id, name, phone, description, account_type_str, pricing_rule_id, payment_term_id = row
+        elif len(row) == 6:
             account_id, name, phone, description, account_type_str, pricing_rule_id = row
+            payment_term_id = None
         else:
             account_id, name, phone, description, account_type_str = row
             pricing_rule_id = None
+            payment_term_id = None
 
         account_type_enum = None
         if account_type_str:
@@ -97,6 +104,7 @@ class Account:
             description=description,
             account_type=account_type_enum,
             pricing_rule_id=pricing_rule_id,
+            payment_term_id=payment_term_id,
         )
 
 @dataclass

--- a/shared/structs.py
+++ b/shared/structs.py
@@ -23,6 +23,19 @@ class PricingRule:
             "fixed_markup": self.fixed_markup,
         }
 
+class PaymentTerm:
+    def __init__(self, term_id: int | None = None, term_name: str = "", days: int | None = None):
+        self.term_id = term_id
+        self.term_name = term_name
+        self.days = days
+
+    def to_dict(self) -> dict:
+        return {
+            "term_id": self.term_id,
+            "term_name": self.term_name,
+            "days": self.days,
+        }
+
 class Product:
     def __init__(
         self,

--- a/ui/accounts/account_popup.py
+++ b/ui/accounts/account_popup.py
@@ -32,18 +32,25 @@ class AccountDetailsPopup(PopupBase):
 
         self.description_entry = self._create_entry("Description:", 4, self.active_account.description)
 
+        # Payment Terms Dropdown
+        tk.Label(self, text="Payment Terms:").grid(row=5, column=0, padx=5, pady=5, sticky="e")
+        self.payment_term_var = tk.StringVar(self)
+        self.payment_term_dropdown = ttk.Combobox(self, textvariable=self.payment_term_var, state="readonly", width=37)
+        self.payment_term_dropdown.grid(row=5, column=1, padx=5, pady=5)
+        self.load_payment_terms()
+
         # Pricing Rule Dropdown
-        tk.Label(self, text="Pricing Rule:").grid(row=5, column=0, padx=5, pady=5, sticky="e")
+        tk.Label(self, text="Pricing Rule:").grid(row=6, column=0, padx=5, pady=5, sticky="e")
         self.pricing_rule_var = tk.StringVar(self)
         self.pricing_rule_dropdown = ttk.Combobox(self, textvariable=self.pricing_rule_var, state="disabled", width=37)
-        self.pricing_rule_dropdown.grid(row=5, column=1, padx=5, pady=5)
+        self.pricing_rule_dropdown.grid(row=6, column=1, padx=5, pady=5)
         self.load_pricing_rules()
         self.toggle_pricing_rule_dropdown()
 
 
         # Addresses Frame
         addresses_frame = tk.LabelFrame(self, text="Addresses")
-        addresses_frame.grid(row=6, column=0, columnspan=2, padx=5, pady=5, sticky="ew")
+        addresses_frame.grid(row=7, column=0, columnspan=2, padx=5, pady=5, sticky="ew")
 
         self.address_tree = ttk.Treeview(addresses_frame, columns=("type", "primary", "address"), show="headings", height=5)
         self.address_tree.heading("type", text="Type")
@@ -62,6 +69,16 @@ class AccountDetailsPopup(PopupBase):
         # Save Button
         save_button = tk.Button(self, text="Save", command=self.save_account)
         save_button.grid(row=18, column=0, columnspan=2, pady=10)
+
+    def load_payment_terms(self):
+        self.payment_terms = self.logic.list_payment_terms()
+        term_names = [term.term_name for term in self.payment_terms]
+        self.payment_term_dropdown['values'] = [""] + term_names
+        if self.active_account.payment_term_id:
+            for term in self.payment_terms:
+                if term.term_id == self.active_account.payment_term_id:
+                    self.payment_term_dropdown.set(term.term_name)
+                    break
 
     def load_pricing_rules(self):
         self.pricing_rules = self.logic.list_pricing_rules()
@@ -147,6 +164,16 @@ class AccountDetailsPopup(PopupBase):
                 return
         else:
             self.active_account.account_type = None
+
+        selected_term_name = self.payment_term_var.get()
+        if selected_term_name:
+            selected_term = next((term for term in self.payment_terms if term.term_name == selected_term_name), None)
+            if selected_term:
+                self.active_account.payment_term_id = selected_term.term_id
+            else:
+                self.active_account.payment_term_id = None
+        else:
+            self.active_account.payment_term_id = None
 
         selected_rule_name = self.pricing_rule_var.get()
         if selected_rule_name:

--- a/ui/main_view.py
+++ b/ui/main_view.py
@@ -19,6 +19,7 @@ from core.address_service import AddressService
 from core.repositories import AddressRepository, AccountRepository, InventoryRepository, ProductRepository
 from core.inventory_service import InventoryService
 from ui.pricing.pricing_rule_tab import PricingRuleTab
+from ui.payment_terms.payment_term_tab import PaymentTermTab
 
 
 class AddressBookView:
@@ -69,6 +70,7 @@ class AddressBookView:
 
         settings_menu = tk.Menu(menu_bar, tearoff=0)
         settings_menu.add_command(label="Company info", command=self.open_company_info)
+        settings_menu.add_command(label="Payment Terms", command=self.open_payment_terms)
         settings_menu.add_command(label="Pricing Rules", command=self.open_pricing_rules)
         menu_bar.add_cascade(label="Settings", menu=settings_menu)
 
@@ -106,3 +108,10 @@ class AddressBookView:
         popup.title("Pricing Rules")
         pricing_tab = PricingRuleTab(popup, self.address_book_logic)
         pricing_tab.frame.pack(fill="both", expand=True)
+
+    def open_payment_terms(self):
+        """Open the payment terms popup."""
+        popup = tk.Toplevel(self.root)
+        popup.title("Payment Terms")
+        term_tab = PaymentTermTab(popup, self.address_book_logic)
+        term_tab.frame.pack(fill="both", expand=True)

--- a/ui/payment_terms/payment_term_popup.py
+++ b/ui/payment_terms/payment_term_popup.py
@@ -1,0 +1,43 @@
+import tkinter as tk
+from tkinter import messagebox
+from shared.structs import PaymentTerm
+from ui.base.popup_base import PopupBase
+
+class PaymentTermPopup(PopupBase):
+    def __init__(self, master, logic, term_id=None):
+        super().__init__(master)
+        self.logic = logic
+        self.term_id = term_id
+
+        if self.term_id is None:
+            self.title("New Payment Term")
+            self.term = PaymentTerm()
+        else:
+            self.title("Edit Payment Term")
+            self.term = self.logic.get_payment_term(self.term_id)
+
+        self.name_entry = self._create_entry("Term Name:", 0, self.term.term_name)
+        self.days_entry = self._create_entry("Days:", 1, self.term.days)
+
+        save_button = tk.Button(self, text="Save", command=self.save_term)
+        save_button.grid(row=2, column=0, columnspan=2, pady=10)
+
+    def save_term(self):
+        term_name = self.name_entry.get()
+        if not self.validate_not_empty(term_name, "Term name"):
+            return
+        days_str = self.days_entry.get()
+        days = None
+        if days_str:
+            try:
+                days = int(days_str)
+            except ValueError:
+                messagebox.showerror("Error", "Days must be an integer.")
+                return
+        self.term.term_name = term_name
+        self.term.days = days
+        if self.term_id is None:
+            self.logic.create_payment_term(self.term.term_name, self.term.days)
+        else:
+            self.logic.update_payment_term(self.term.term_id, self.term.term_name, self.term.days)
+        self.destroy()

--- a/ui/payment_terms/payment_term_tab.py
+++ b/ui/payment_terms/payment_term_tab.py
@@ -1,0 +1,85 @@
+import tkinter as tk
+from tkinter import messagebox, ttk
+from ui.payment_terms.payment_term_popup import PaymentTermPopup
+from shared.structs import PaymentTerm
+
+class PaymentTermTab:
+    def __init__(self, master, logic):
+        self.frame = tk.Frame(master)
+        self.logic = logic
+        self.selected_term_id = None
+
+        self.setup_ui()
+        self.load_terms()
+
+        self.frame.bind("<FocusIn>", lambda event: self.load_terms())
+
+    def setup_ui(self):
+        tk.Label(self.frame, text="Payment Terms").grid(row=0, column=0, padx=5, pady=5, sticky="w")
+
+        button_width = 20
+        button_frame = tk.Frame(self.frame)
+        button_frame.grid(row=1, column=0, columnspan=3, pady=5, sticky="w")
+
+        self.add_button = tk.Button(button_frame, text="New", command=self.create_new_term, width=button_width)
+        self.add_button.pack(side=tk.LEFT, padx=5)
+
+        self.edit_button = tk.Button(button_frame, text="Edit", command=self.edit_existing_term, width=button_width)
+        self.edit_button.pack(side=tk.LEFT, padx=5)
+
+        self.delete_button = tk.Button(button_frame, text="Delete", command=self.delete_term, width=button_width)
+        self.delete_button.pack(side=tk.LEFT, padx=5)
+
+        self.tree = ttk.Treeview(self.frame, columns=("id", "name", "days"), show="headings")
+        self.tree.column("id", width=0, stretch=False)
+        self.tree.heading("name", text="Term Name")
+        self.tree.heading("days", text="Days")
+        self.tree.grid(row=2, column=0, columnspan=3, padx=5, pady=5, sticky="nsew")
+        self.tree.bind("<<TreeviewSelect>>", self.select_term)
+
+        self.frame.grid_rowconfigure(2, weight=1)
+        self.frame.grid_columnconfigure(0, weight=1)
+
+    def load_terms(self):
+        for i in self.tree.get_children():
+            self.tree.delete(i)
+        terms = self.logic.list_payment_terms()
+        for term in terms:
+            self.tree.insert("", "end", values=(
+                term.term_id,
+                term.term_name,
+                term.days if term.days is not None else "N/A",
+            ))
+
+    def select_term(self, event=None):
+        selected_item = self.tree.selection()
+        if selected_item:
+            self.selected_term_id = self.tree.item(selected_item[0], 'values')[0]
+        else:
+            self.selected_term_id = None
+
+    def create_new_term(self):
+        popup = PaymentTermPopup(self.frame, self.logic, None)
+        self.frame.wait_window(popup)
+        self.load_terms()
+
+    def edit_existing_term(self):
+        if not self.selected_term_id:
+            messagebox.showwarning("No Selection", "Please select a term to edit.")
+            return
+        popup = PaymentTermPopup(self.frame, self.logic, self.selected_term_id)
+        self.frame.wait_window(popup)
+        self.load_terms()
+
+    def delete_term(self):
+        if not self.selected_term_id:
+            messagebox.showwarning("No Selection", "Please select a term to delete.")
+            return
+        confirm = messagebox.askyesno("Confirm Delete", f"Are you sure you want to delete term ID: {self.selected_term_id}?")
+        if confirm:
+            try:
+                self.logic.delete_payment_term(int(self.selected_term_id))
+                messagebox.showinfo("Success", "Term deleted successfully.")
+                self.load_terms()
+            except Exception as e:
+                messagebox.showerror("Error", f"Failed to delete term: {e}")


### PR DESCRIPTION
## Summary
- introduce payment terms data model and schema
- allow defining payment terms in settings popup
- enable choosing a payment term on account forms

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e3d508fb88331a9fb05cc34eaf495