### PR TITLE
Implement partial purchase receipts tracking

### DIFF
--- a/core/inventory_service.py
+++ b/core/inventory_service.py
@@ -60,3 +60,22 @@ class InventoryService:
     def get_on_order_level(self, product_id: int) -> float:
         """Return the quantity currently on order for a product."""
         return self.inventory_repo.get_on_order_level(product_id)
+
+    def get_products_on_order(self) -> list[dict]:
+        """Return products with aggregated on-order quantities and on-hand stock."""
+        entries = self.inventory_repo.get_all_on_order_levels()
+        result = []
+        for entry in entries:
+            pid = entry.get("product_id")
+            product = self.product_repo.get_product_details(pid)
+            if not product:
+                continue
+            result.append(
+                {
+                    "product_id": pid,
+                    "name": product.get("name"),
+                    "on_hand": product.get("quantity_on_hand", 0),
+                    "on_order": entry.get("qty", 0),
+                }
+            )
+        return result

--- a/core/repositories.py
+++ b/core/repositories.py
@@ -240,6 +240,18 @@ class PurchaseRepository:
     def get_items_for_document(self, doc_id: int):
         return self.db.get_items_for_document(doc_id)
 
+    def add_purchase_receipt(self, item_id: int, quantity: float, received_date: str | None = None):
+        return self.db.add_purchase_receipt(item_id, quantity, received_date)
+
+    def get_total_received_for_item(self, item_id: int) -> float:
+        return self.db.get_total_received_for_item(item_id)
+
+    def mark_item_fully_received(self, item_id: int):
+        self.db.mark_purchase_item_received(item_id)
+
+    def are_all_items_received(self, doc_id: int) -> bool:
+        return self.db.are_all_items_received(doc_id)
+
 
 class InteractionRepository:
     """Repository for interaction-related operations."""
@@ -317,6 +329,9 @@ class InventoryRepository:
 
     def get_on_order_level(self, product_id: int) -> float:
         return self.db.get_on_order_quantity(product_id)
+
+    def get_all_on_order_levels(self):
+        return self.db.get_all_on_order_quantities()
 
     def add_replenishment_item(self, product_id: int, quantity_needed: float):
         return self.db.add_replenishment_item(product_id, quantity_needed)

--- a/core/schema/purchase.py
+++ b/core/schema/purchase.py
@@ -27,10 +27,23 @@ def create_schema(cursor: sqlite3.Cursor) -> None:
             unit_price REAL,
             total_price REAL,
             note TEXT,
+            is_received BOOLEAN DEFAULT FALSE,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (purchase_document_id) REFERENCES purchase_documents(id),
             FOREIGN KEY (product_id) REFERENCES products(id)
+        )
+    """)
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS purchase_receipts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            purchase_document_item_id INTEGER NOT NULL,
+            quantity REAL NOT NULL,
+            received_date TEXT NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (purchase_document_item_id) REFERENCES purchase_document_items(id)
         )
     """)
 
@@ -49,5 +62,14 @@ def create_schema(cursor: sqlite3.Cursor) -> None:
         FOR EACH ROW
         BEGIN
             UPDATE purchase_document_items SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id;
+        END;
+    """)
+
+    cursor.execute("""
+        CREATE TRIGGER IF NOT EXISTS update_purchase_receipts_updated_at
+        AFTER UPDATE ON purchase_receipts
+        FOR EACH ROW
+        BEGIN
+            UPDATE purchase_receipts SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id;
         END;
     """)

--- a/shared/structs.py
+++ b/shared/structs.py
@@ -289,7 +289,8 @@ class PurchaseDocumentItem:
     def __init__(self, item_id=None, purchase_document_id: int = None, product_id: Optional[int] = None,
                  product_description: str = "", quantity: float = 0.0,
                  unit_price: float = None, total_price: float = None,
-                 note: str | None = None):
+                 note: str | None = None, received_quantity: float = 0.0,
+                 is_received: bool = False):
         self.id = item_id  # Using 'id'
         self.purchase_document_id = purchase_document_id
         self.product_id = product_id
@@ -298,6 +299,8 @@ class PurchaseDocumentItem:
         self.unit_price = unit_price
         self.total_price = total_price  # Should be calculated quantity * unit_price if unit_price is known
         self.note = note
+        self.received_quantity = received_quantity
+        self.is_received = is_received
 
     def calculate_total_price(self):
         """Calculates total price if quantity and unit_price are set."""
@@ -317,6 +320,8 @@ class PurchaseDocumentItem:
             "unit_price": self.unit_price,
             "total_price": self.total_price,
             "note": self.note,
+            "received_quantity": self.received_quantity,
+            "is_received": self.is_received,
         }
 
     def __str__(self) -> str:

--- a/tests/unit/test_structs.py
+++ b/tests/unit/test_structs.py
@@ -101,6 +101,8 @@ class TestPurchaseDocumentItemClass(unittest.TestCase):
         self.assertIsNone(item.unit_price)
         self.assertIsNone(item.total_price)
         self.assertIsNone(item.note)
+        self.assertEqual(item.received_quantity, 0.0)
+        self.assertFalse(item.is_received)
 
     def test_item_creation_with_values(self):
         item = PurchaseDocumentItem(item_id=100, purchase_document_id=1, product_description="Test Product",
@@ -112,6 +114,8 @@ class TestPurchaseDocumentItemClass(unittest.TestCase):
         self.assertEqual(item.unit_price, 2.0)
         self.assertEqual(item.total_price, 21.0)
         self.assertEqual(item.note, "Sample")
+        self.assertEqual(item.received_quantity, 0.0)
+        self.assertFalse(item.is_received)
 
     def test_item_calculate_total_price(self):
         item = PurchaseDocumentItem(quantity=5, unit_price=10.0)
@@ -136,7 +140,8 @@ class TestPurchaseDocumentItemClass(unittest.TestCase):
         expected_dict = {
             "id": 1, "purchase_document_id": 2, "product_id": None, # Added product_id
             "product_description": "Another Product",
-            "quantity": 3, "unit_price": 5.0, "total_price": 15.0, "note": None
+            "quantity": 3, "unit_price": 5.0, "total_price": 15.0, "note": None,
+            "received_quantity": 0.0, "is_received": False,
         }
         self.assertEqual(item_dict, expected_dict)
 

--- a/ui/inventory/inventory_tab.py
+++ b/ui/inventory/inventory_tab.py
@@ -99,12 +99,22 @@ class InventoryTab:
         self.refresh_ready_to_ship()
 
     def refresh_to_receive(self):
+        expanded_docs = {
+            iid
+            for iid in self.to_receive_tree.get_children()
+            if self.to_receive_tree.item(iid, "open")
+        }
         self.to_receive_tree.delete(*self.to_receive_tree.get_children())
         self.selected_item_id = None
-        docs = self.purchase_logic.get_all_documents_by_criteria(status=PurchaseDocumentStatus.PO_ISSUED)
+        docs = self.purchase_logic.get_all_documents_by_criteria(
+            status=PurchaseDocumentStatus.PO_ISSUED
+        )
         for doc in docs:
             doc_iid = f"doc_{doc.id}"
-            self.to_receive_tree.insert("", "end", iid=doc_iid, text=doc.document_number, open=False)
+            is_open = doc_iid in expanded_docs
+            self.to_receive_tree.insert(
+                "", "end", iid=doc_iid, text=doc.document_number, open=is_open
+            )
             items = self.purchase_logic.get_items_for_document(doc.id)
             for item in items:
                 remaining = item.quantity - item.received_quantity

--- a/ui/inventory/record_receipt_popup.py
+++ b/ui/inventory/record_receipt_popup.py
@@ -1,0 +1,50 @@
+import tkinter as tk
+from tkinter import messagebox
+from core.purchase_logic import PurchaseLogic
+from shared.structs import PurchaseDocumentItem
+
+
+class RecordReceiptPopup(tk.Toplevel):
+    def __init__(self, master, purchase_logic: PurchaseLogic, item: PurchaseDocumentItem, refresh_callback=None):
+        super().__init__(master)
+        self.purchase_logic = purchase_logic
+        self.item = item
+        self.refresh_callback = refresh_callback
+
+        self.title("Record Receipt")
+        self.geometry("300x220")
+
+        tk.Label(self, text=f"Product: {item.product_description}").grid(row=0, column=0, columnspan=2, padx=5, pady=5, sticky="w")
+        tk.Label(self, text=f"Ordered: {item.quantity}").grid(row=1, column=0, columnspan=2, padx=5, pady=5, sticky="w")
+        tk.Label(self, text=f"Received: {item.received_quantity}").grid(row=2, column=0, columnspan=2, padx=5, pady=5, sticky="w")
+        remaining = item.quantity - item.received_quantity
+        tk.Label(self, text=f"Remaining: {remaining}").grid(row=3, column=0, columnspan=2, padx=5, pady=5, sticky="w")
+
+        tk.Label(self, text="Quantity to Receive:").grid(row=4, column=0, padx=5, pady=5, sticky="w")
+        self.qty_entry = tk.Entry(self, width=10)
+        self.qty_entry.grid(row=4, column=1, padx=5, pady=5, sticky="w")
+
+        tk.Button(self, text="Record", command=self.record_receipt).grid(row=5, column=0, padx=5, pady=10, sticky="e")
+        tk.Button(self, text="Cancel", command=self.destroy).grid(row=5, column=1, padx=5, pady=10, sticky="w")
+
+    def record_receipt(self):
+        qty_str = self.qty_entry.get().strip()
+        try:
+            qty = float(qty_str)
+        except ValueError:
+            messagebox.showerror("Validation Error", "Quantity must be a number.", parent=self)
+            return
+
+        remaining = self.item.quantity - self.item.received_quantity
+        if qty <= 0 or qty > remaining:
+            messagebox.showerror("Validation Error", f"Quantity must be between 0 and {remaining}.", parent=self)
+            return
+
+        try:
+            self.purchase_logic.record_item_receipt(self.item.id, qty)
+            messagebox.showinfo("Success", "Receipt recorded.", parent=self)
+            if self.refresh_callback:
+                self.refresh_callback()
+            self.destroy()
+        except Exception as e:
+            messagebox.showerror("Error", f"Failed to record receipt: {e}", parent=self)

--- a/ui/main_view.py
+++ b/ui/main_view.py
@@ -86,7 +86,7 @@ class AddressBookView:
             self.notebook, self.sales_logic, self.address_book_logic, self.product_logic
         )  # Add Sales Documents tab
         self.inventory_tab = InventoryTab(
-            self.notebook, self.purchase_logic, self.product_logic
+            self.notebook, self.purchase_logic, self.product_logic, self.sales_logic
         )
 
 

--- a/ui/main_view.py
+++ b/ui/main_view.py
@@ -11,6 +11,7 @@ from core.purchase_logic import PurchaseLogic
 from ui.purchase_documents.purchase_document_tab import PurchaseDocumentTab
 from core.sales_logic import SalesLogic # Import SalesLogic
 from ui.sales_documents.sales_document_tab import SalesDocumentTab # Import SalesDocumentTab
+from ui.inventory.inventory_tab import InventoryTab
 # Company information popup
 from ui.company_info_tab import CompanyInfoTab
 from core.company_repository import CompanyRepository
@@ -84,6 +85,9 @@ class AddressBookView:
         self.sales_document_tab = SalesDocumentTab(
             self.notebook, self.sales_logic, self.address_book_logic, self.product_logic
         )  # Add Sales Documents tab
+        self.inventory_tab = InventoryTab(
+            self.notebook, self.purchase_logic, self.product_logic
+        )
 
 
         # Add frames from tabs to Notebook
@@ -94,6 +98,7 @@ class AddressBookView:
         self.notebook.add(self.product_tab.frame, text="Products")
         self.notebook.add(self.purchase_document_tab.frame, text="Purchase")
         self.notebook.add(self.sales_document_tab.frame, text="Sales")
+        self.notebook.add(self.inventory_tab.frame, text="Inventory")
 
     def open_company_info(self):
         """Open the company information popup."""


### PR DESCRIPTION
## Summary
- Track receipt history per purchase line with new `purchase_receipts` table and item `is_received` flag
- Update purchase logic to record partial receipts, adjust inventory incrementally, and complete documents when fully received
- Expose receipt operations through repositories and data structures
- Add Inventory tab to manage receipts and view stock levels
- Aggregate on-order quantities per product and display them in Inventory tab

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e5c1b28ac8331894aa9243302ffe6