### PR TITLE
Allow addresses to support multiple types

### DIFF
--- a/core/address_book_logic.py
+++ b/core/address_book_logic.py
@@ -134,18 +134,25 @@ class AddressBookLogic:
                     logger.warning("Invalid account type string '%s' in DB for account ID %s", account_type_str, data.get('id'))
 
             addresses = []
+            address_map: dict[int, Address] = {}
             for addr_data in data.get('addresses', []):
-                address = Address(
-                    address_id=addr_data['address_id'],
-                    street=addr_data['street'],
-                    city=addr_data['city'],
-                    state=addr_data['state'],
-                    zip_code=addr_data['zip'],
-                    country=addr_data['country']
-                )
-                address.address_type = addr_data['address_type']
-                address.is_primary = addr_data['is_primary']
-                addresses.append(address)
+                addr_id = addr_data['address_id']
+                address = address_map.get(addr_id)
+                if not address:
+                    address = Address(
+                        address_id=addr_id,
+                        street=addr_data['street'],
+                        city=addr_data['city'],
+                        state=addr_data['state'],
+                        zip_code=addr_data['zip'],
+                        country=addr_data['country']
+                    )
+                    address_map[addr_id] = address
+                atype = addr_data['address_type']
+                address.types.append(atype)
+                if addr_data['is_primary']:
+                    address.primary_types.append(atype)
+            addresses = list(address_map.values())
 
             return Account(
                 account_id=data.get("id"),  # Ensure key matches db output

--- a/core/invoice_generator.py
+++ b/core/invoice_generator.py
@@ -53,14 +53,14 @@ def generate_invoice_pdf(sales_document_id: int, output_path: str = None):
             customer = address_book_logic.get_account_details(doc.customer_id)
             if customer:
                 for address in customer.addresses:
-                    if address.address_type == 'Billing' and address.is_primary:
+                    if 'Billing' in address.types and 'Billing' in address.primary_types:
                         customer_billing_address = address
-                    if address.address_type == 'Shipping' and address.is_primary:
+                    if 'Shipping' in address.types and 'Shipping' in address.primary_types:
                         customer_shipping_address = address
-                if not customer_billing_address and any(addr.address_type == 'Billing' for addr in customer.addresses):
-                    customer_billing_address = next(addr for addr in customer.addresses if addr.address_type == 'Billing')
-                if not customer_shipping_address and any(addr.address_type == 'Shipping' for addr in customer.addresses):
-                    customer_shipping_address = next(addr for addr in customer.addresses if addr.address_type == 'Shipping')
+                if not customer_billing_address and any('Billing' in addr.types for addr in customer.addresses):
+                    customer_billing_address = next(addr for addr in customer.addresses if 'Billing' in addr.types)
+                if not customer_shipping_address and any('Shipping' in addr.types for addr in customer.addresses):
+                    customer_shipping_address = next(addr for addr in customer.addresses if 'Shipping' in addr.types)
 
         items: list[SalesDocumentItem] = sales_logic.get_items_for_sales_document(doc.id)
 

--- a/core/pdf_generator.py
+++ b/core/pdf_generator.py
@@ -91,15 +91,15 @@ def get_company_pdf_context(service: CompanyService):
     company_phone = company.phone or ""
 
     billing_addr = next(
-        (a for a in company.addresses if a.address_type == "Billing" and getattr(a, "is_primary", False)),
+        (a for a in company.addresses if "Billing" in a.types and "Billing" in a.primary_types),
         None,
     )
     shipping_addr = next(
-        (a for a in company.addresses if a.address_type == "Shipping" and getattr(a, "is_primary", False)),
+        (a for a in company.addresses if "Shipping" in a.types and "Shipping" in a.primary_types),
         None,
     )
     remittance_addr = next(
-        (a for a in company.addresses if a.address_type == "Remittance" and getattr(a, "is_primary", False)),
+        (a for a in company.addresses if "Remittance" in a.types and "Remittance" in a.primary_types),
         None,
     )
 

--- a/core/quote_generator.py
+++ b/core/quote_generator.py
@@ -53,14 +53,14 @@ def generate_quote_pdf(sales_document_id: int, output_path: str = None):
             customer = address_book_logic.get_account_details(doc.customer_id)
             if customer:
                 for address in customer.addresses:
-                    if address.address_type == 'Billing' and address.is_primary:
+                    if 'Billing' in address.types and 'Billing' in address.primary_types:
                         customer_billing_address = address
-                    if address.address_type == 'Shipping' and address.is_primary:
+                    if 'Shipping' in address.types and 'Shipping' in address.primary_types:
                         customer_shipping_address = address
-                if not customer_billing_address and any(addr.address_type == 'Billing' for addr in customer.addresses):
-                    customer_billing_address = next(addr for addr in customer.addresses if addr.address_type == 'Billing')
-                if not customer_shipping_address and any(addr.address_type == 'Shipping' for addr in customer.addresses):
-                    customer_shipping_address = next(addr for addr in customer.addresses if addr.address_type == 'Shipping')
+                if not customer_billing_address and any('Billing' in addr.types for addr in customer.addresses):
+                    customer_billing_address = next(addr for addr in customer.addresses if 'Billing' in addr.types)
+                if not customer_shipping_address and any('Shipping' in addr.types for addr in customer.addresses):
+                    customer_shipping_address = next(addr for addr in customer.addresses if 'Shipping' in addr.types)
 
         items: list[SalesDocumentItem] = sales_logic.get_items_for_sales_document(doc.id)
 

--- a/core/sales_order_generator.py
+++ b/core/sales_order_generator.py
@@ -53,14 +53,14 @@ def generate_sales_order_pdf(sales_document_id: int, output_path: str = None):
             customer = address_book_logic.get_account_details(doc.customer_id)
             if customer:
                 for address in customer.addresses:
-                    if address.address_type == 'Billing' and address.is_primary:
+                    if 'Billing' in address.types and 'Billing' in address.primary_types:
                         customer_billing_address = address
-                    if address.address_type == 'Shipping' and address.is_primary:
+                    if 'Shipping' in address.types and 'Shipping' in address.primary_types:
                         customer_shipping_address = address
-                if not customer_billing_address and any(addr.address_type == 'Billing' for addr in customer.addresses):
-                    customer_billing_address = next(addr for addr in customer.addresses if addr.address_type == 'Billing')
-                if not customer_shipping_address and any(addr.address_type == 'Shipping' for addr in customer.addresses):
-                    customer_shipping_address = next(addr for addr in customer.addresses if addr.address_type == 'Shipping')
+                if not customer_billing_address and any('Billing' in addr.types for addr in customer.addresses):
+                    customer_billing_address = next(addr for addr in customer.addresses if 'Billing' in addr.types)
+                if not customer_shipping_address and any('Shipping' in addr.types for addr in customer.addresses):
+                    customer_shipping_address = next(addr for addr in customer.addresses if 'Shipping' in addr.types)
 
         items: list[SalesDocumentItem] = sales_logic.get_items_for_sales_document(doc.id)
 

--- a/ui/accounts/account_popup.py
+++ b/ui/accounts/account_popup.py
@@ -102,12 +102,14 @@ class AccountDetailsPopup(PopupBase):
             self.address_tree.delete(i)
         for i, addr in enumerate(self.active_account.addresses):
             address_str = f"{addr.street}, {addr.city}, {addr.state} {addr.zip_code}, {addr.country}"
+            type_str = ", ".join(addr.types)
+            primary_str = ", ".join(addr.primary_types)
             self.address_tree.insert(
                 "",
                 "end",
                 values=(
-                    addr.address_type,
-                    "true" if getattr(addr, "is_primary", False) else "false",
+                    type_str,
+                    primary_str,
                     address_str,
                 ),
                 iid=i,
@@ -119,10 +121,6 @@ class AccountDetailsPopup(PopupBase):
         if hasattr(address_popup, 'address'):
             if not hasattr(address_popup.address, 'address_id'):
                 address_popup.address.address_id = None
-            if not hasattr(address_popup.address, 'address_type'):
-                address_popup.address.address_type = ''
-            if not hasattr(address_popup.address, 'is_primary'):
-                address_popup.address.is_primary = False
             self.active_account.addresses.append(address_popup.address)
             self.populate_address_tree()
 
@@ -202,22 +200,33 @@ class AddressPopup(PopupBase):
         self.state_entry = self._create_entry("State:", 2, self.address.state)
         self.zip_entry = self._create_entry("Zip:", 3, self.address.zip_code)
         self.country_entry = self._create_entry("Country:", 4, self.address.country)
-        tk.Label(self, text="Type:").grid(row=5, column=0, padx=5, pady=5, sticky="e")
-        self.type_var = tk.StringVar(self)
-        self.type_dropdown = ttk.Combobox(
-            self,
-            textvariable=self.type_var,
-            values=["Billing", "Shipping", "Remittance"],
-            state="readonly",
-            width=37,
-        )
-        if hasattr(self.address, 'address_type'):
-            self.type_dropdown.set(self.address.address_type)
-        self.type_dropdown.grid(row=5, column=1, padx=5, pady=5)
-        self.primary_var = tk.BooleanVar(value=self.address.is_primary if hasattr(self.address, 'is_primary') else False)
-        self.primary_check = tk.Checkbutton(self, text="Primary", variable=self.primary_var)
-        self.primary_check.grid(row=6, column=0, columnspan=2)
-        tk.Button(self, text="Save", command=self.save).grid(row=7, column=0, columnspan=2)
+
+        tk.Label(self, text="Type").grid(row=5, column=0, padx=5, pady=(10, 5))
+        tk.Label(self, text="Use").grid(row=5, column=1, padx=5, pady=(10, 5))
+        tk.Label(self, text="Primary").grid(row=5, column=2, padx=5, pady=(10, 5))
+
+        self.type_vars: dict[str, tk.BooleanVar] = {}
+        self.primary_vars: dict[str, tk.BooleanVar] = {}
+        self.primary_checks: dict[str, tk.Checkbutton] = {}
+        address_types = ["Billing", "Shipping", "Remittance"]
+        current_types = getattr(self.address, 'types', [])
+        current_primary = getattr(self.address, 'primary_types', [])
+        for i, atype in enumerate(address_types):
+            row = 6 + i
+            tk.Label(self, text=atype + ":").grid(row=row, column=0, sticky="e", padx=5, pady=2)
+            type_var = tk.BooleanVar(value=atype in current_types)
+            type_cb = tk.Checkbutton(self, variable=type_var, command=lambda a=atype: self._on_type_toggle(a))
+            type_cb.grid(row=row, column=1, padx=5, pady=2)
+            primary_var = tk.BooleanVar(value=atype in current_primary)
+            primary_cb = tk.Checkbutton(self, variable=primary_var)
+            primary_cb.grid(row=row, column=2, padx=5, pady=2)
+            if not type_var.get():
+                primary_cb.config(state="disabled")
+            self.type_vars[atype] = type_var
+            self.primary_vars[atype] = primary_var
+            self.primary_checks[atype] = primary_cb
+
+        tk.Button(self, text="Save", command=self.save).grid(row=9, column=0, columnspan=3, pady=5)
 
     def save(self):
         self.address.street = self.street_entry.get()
@@ -225,10 +234,13 @@ class AddressPopup(PopupBase):
         self.address.state = self.state_entry.get()
         self.address.zip_code = self.zip_entry.get()
         self.address.country = self.country_entry.get()
-        self.address.address_type = self.type_var.get()
-        self.address.is_primary = self.primary_var.get()
-        if self.address.is_primary:
-            for addr in getattr(self.master, "active_account", Account()).addresses:
-                if addr is not self.address and getattr(addr, "address_type", None) == self.address.address_type:
-                    addr.is_primary = False
+        self.address.types = [t for t, v in self.type_vars.items() if v.get()]
+        self.address.primary_types = [t for t, v in self.primary_vars.items() if v.get()]
         self.destroy()
+
+    def _on_type_toggle(self, atype):
+        if self.type_vars[atype].get():
+            self.primary_checks[atype].config(state="normal")
+        else:
+            self.primary_vars[atype].set(False)
+            self.primary_checks[atype].config(state="disabled")

--- a/ui/sales_documents/sales_document_popup.py
+++ b/ui/sales_documents/sales_document_popup.py
@@ -318,19 +318,19 @@ class SalesDocumentPopup(Toplevel): # Changed from tk.Toplevel for directness
         if customer_id:
             customer = self.account_logic.get_account_details(customer_id)
             if customer:
-                billing_addresses = [addr for addr in customer.addresses if addr.address_type == 'Billing']
-                shipping_addresses = [addr for addr in customer.addresses if addr.address_type == 'Shipping']
+                billing_addresses = [addr for addr in customer.addresses if 'Billing' in getattr(addr, 'types', [])]
+                shipping_addresses = [addr for addr in customer.addresses if 'Shipping' in getattr(addr, 'types', [])]
 
                 self.billing_address_combobox['values'] = [f"{addr.street}, {addr.city}" for addr in billing_addresses]
                 self.shipping_address_combobox['values'] = [f"{addr.street}, {addr.city}" for addr in shipping_addresses]
 
-                primary_billing = next((addr for addr in billing_addresses if addr.is_primary), None)
+                primary_billing = next((addr for addr in billing_addresses if 'Billing' in addr.primary_types), None)
                 if primary_billing:
                     self.billing_address_combobox.set(f"{primary_billing.street}, {primary_billing.city}")
                 elif billing_addresses:
                     self.billing_address_combobox.set(f"{billing_addresses[0].street}, {billing_addresses[0].city}")
 
-                primary_shipping = next((addr for addr in shipping_addresses if addr.is_primary), None)
+                primary_shipping = next((addr for addr in shipping_addresses if 'Shipping' in addr.primary_types), None)
                 if primary_shipping:
                     self.shipping_address_combobox.set(f"{primary_shipping.street}, {primary_shipping.city}")
                 elif shipping_addresses:


### PR DESCRIPTION
## Summary
- Let Address objects store multiple types and per-type primaries
- Persist each selected type and enforce one primary per type when saving accounts and company info
- Update address popups and customer address pickers to select multiple types

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eb73cad308331a3a8cd91ff112b65