### PR TITLE
Add shipment tracking display for sales orders

### DIFF
--- a/core/repositories.py
+++ b/core/repositories.py
@@ -300,6 +300,9 @@ class SalesRepository:
     def get_items_for_sales_document(self, doc_id: int):
         return self.db.get_items_for_sales_document(doc_id)
 
+    def get_shipments_for_sales_document(self, doc_id: int):
+        return self.db.get_shipments_for_sales_document(doc_id)
+
     def get_sales_document_item_by_id(self, item_id: int):
         return self.db.get_sales_document_item_by_id(item_id)
 

--- a/core/sales_logic.py
+++ b/core/sales_logic.py
@@ -538,6 +538,23 @@ class SalesLogic:
             )
         return None
 
+    def get_shipments_for_order(self, doc_id: int) -> List[dict]:
+        shipments_data = self.sales_repo.get_shipments_for_sales_document(doc_id)
+        shipments: dict[int, dict] = {}
+        for row in shipments_data:
+            sid = row["shipment_id"]
+            shipment = shipments.setdefault(
+                sid, {"id": sid, "created_at": row["created_at"], "items": []}
+            )
+            shipment["items"].append(
+                {
+                    "item_id": row["item_id"],
+                    "product_description": row["product_description"],
+                    "quantity": row["quantity"],
+                }
+            )
+        return list(shipments.values())
+
     def delete_sales_document_item(self, item_id: int):
         item = self.get_sales_document_item_details(item_id)
         if not item:

--- a/tests/integration/test_sales_shipments.py
+++ b/tests/integration/test_sales_shipments.py
@@ -1,0 +1,76 @@
+import os
+import subprocess
+import time
+import unittest
+import tkinter as tk
+from unittest.mock import MagicMock
+
+from core.database import DatabaseHandler
+from core.sales_logic import SalesLogic
+from core.address_book_logic import AddressBookLogic
+from shared.structs import AccountType
+from ui.sales_documents.sales_document_popup import SalesDocumentPopup
+
+
+class SalesShipmentsUITest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.xvfb = subprocess.Popen(["Xvfb", ":1"])
+        os.environ["DISPLAY"] = ":1"
+        time.sleep(0.5)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.xvfb.terminate()
+
+    def setUp(self):
+        self.db = DatabaseHandler(":memory:")
+        self.sales_logic = SalesLogic(self.db)
+        self.address_logic = AddressBookLogic(self.db)
+        self.root = tk.Tk()
+        self.root.withdraw()
+
+        self.customer_id = self.db.add_account(
+            "Cust", None, None, None, AccountType.CUSTOMER.value
+        )
+        self.product_id = self.db.add_product(
+            sku="P1",
+            name="Product",
+            description="",
+            cost=1.0,
+            sale_price=10.0,
+            is_active=True,
+            quantity_on_hand=10,
+        )
+        quote = self.sales_logic.create_quote(
+            self.customer_id, reference_number="REF"
+        )
+        self.sales_logic.add_item_to_sales_document(
+            quote.id, self.product_id, 5, unit_price_override=10.0
+        )
+        self.so = self.sales_logic.convert_quote_to_sales_order(quote.id)
+        items = self.sales_logic.get_items_for_sales_document(self.so.id)
+        self.sales_logic.record_item_shipment(items[0].id, 2)
+
+    def tearDown(self):
+        self.root.destroy()
+        self.db.close()
+
+    def test_shipments_displayed(self):
+        popup = SalesDocumentPopup(
+            self.root,
+            self.sales_logic,
+            self.address_logic,
+            MagicMock(),
+            document_id=self.so.id,
+        )
+        shipments = popup.shipments_tree.get_children()
+        self.assertEqual(len(shipments), 1)
+        first = shipments[0]
+        subitems = popup.shipments_tree.get_children(first)
+        self.assertEqual(len(subitems), 1)
+        popup.destroy()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_sales_logic.py
+++ b/tests/unit/test_sales_logic.py
@@ -755,3 +755,33 @@ class TestSalesLogicWithPricingRules(unittest.TestCase):
 
         self.assertEqual(updated_item.unit_price, 110.0)
         self.assertEqual(updated_item.quantity, 2)
+
+    def test_get_shipments_for_order(self):
+        mock_data = [
+            {
+                "shipment_id": 1,
+                "created_at": "2024-01-01",
+                "item_id": 10,
+                "product_description": "Widget",
+                "quantity": 2,
+            }
+        ]
+        self.sales_logic.sales_repo.get_shipments_for_sales_document = MagicMock(
+            return_value=mock_data
+        )
+        shipments = self.sales_logic.get_shipments_for_order(5)
+        expected = [
+            {
+                "id": 1,
+                "created_at": "2024-01-01",
+                "items": [
+                    {
+                        "item_id": 10,
+                        "product_description": "Widget",
+                        "quantity": 2,
+                    }
+                ],
+            }
+        ]
+        self.assertEqual(shipments, expected)
+        self.sales_logic.sales_repo.get_shipments_for_sales_document.assert_called_once_with(5)

--- a/tests/unit/test_sales_repository.py
+++ b/tests/unit/test_sales_repository.py
@@ -1,0 +1,20 @@
+import unittest
+from unittest.mock import MagicMock
+
+from core.repositories import SalesRepository
+
+
+class TestSalesRepository(unittest.TestCase):
+    def test_get_shipments_for_sales_document(self):
+        mock_db = MagicMock()
+        repo = SalesRepository(mock_db)
+        mock_db.get_shipments_for_sales_document.return_value = [
+            {"shipment_id": 1}
+        ]
+        result = repo.get_shipments_for_sales_document(5)
+        self.assertEqual(result, [{"shipment_id": 1}])
+        mock_db.get_shipments_for_sales_document.assert_called_once_with(5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add database and repository methods to collect shipment records for sales orders
- expose shipments via `SalesLogic.get_shipments_for_order`
- display shipments and items in sales document popup
- add unit and UI integration tests for shipment retrieval

## Testing
- `pytest tests/unit/test_sales_repository.py tests/unit/test_sales_logic.py tests/integration/test_sales_shipments.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688ec569282883318ac212a909cd1d1a