### PR TITLE
Enable multi-line item shipments with sequential IDs

### DIFF
--- a/core/repositories.py
+++ b/core/repositories.py
@@ -303,6 +303,9 @@ class SalesRepository:
     def get_shipments_for_sales_document(self, doc_id: int):
         return self.db.get_shipments_for_sales_document(doc_id)
 
+    def get_shipment_references_for_sales_document(self, doc_id: int) -> list[str]:
+        return self.db.get_shipment_references_for_sales_document(doc_id)
+
     def get_sales_document_item_by_id(self, item_id: int):
         return self.db.get_sales_document_item_by_id(item_id)
 

--- a/ui/sales_documents/sales_document_popup.py
+++ b/ui/sales_documents/sales_document_popup.py
@@ -435,7 +435,7 @@ class SalesDocumentPopup(Toplevel): # Changed from tk.Toplevel for directness
             shipments = self.sales_logic.get_shipments_for_order(self.document_data.id)
             for shipment in shipments:
                 parent = self.shipments_tree.insert(
-                    "", tk.END, text=f"Shipment {shipment['id']} - {shipment['created_at']}", open=True
+                    "", tk.END, text=f"Shipment {shipment['number']} - {shipment['created_at']}", open=True
                 )
                 for item in shipment["items"]:
                     self.shipments_tree.insert(


### PR DESCRIPTION
## Summary
- Group multiple sales order items into a single shipment with sequential identifiers
- Support shipment entry for entire orders and track shipment references per order
- Display shipments by order and item in the UI

## Testing
- `pytest tests/unit/test_sales_logic.py::TestSalesLogic::test_record_item_shipment_partial -q`
- `pytest tests/unit/test_sales_logic.py::TestSalesLogic::test_record_item_shipment_completes_document tests/unit/test_sales_logic.py::TestSalesLogic::test_record_item_shipment_insufficient_stock tests/unit/test_sales_logic.py::TestSalesLogic::test_record_shipment_multiple_items -q`
- `pytest tests/unit/test_sales_logic.py::TestSalesLogicWithPricingRules::test_get_shipments_for_order -q`
- `pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'Xvfb')*

------
https://chatgpt.com/codex/tasks/task_e_688eca5b57f483318d24c9b901f58c6d