### PR TITLE
Add packing slip generator and export option for shipments

### DIFF
--- a/core/packing_slip_generator.py
+++ b/core/packing_slip_generator.py
@@ -89,6 +89,18 @@ def generate_packing_slip_pdf(
                     description = prod["name"]
             shipped_items.append((description, qty))
 
+        outstanding_items: list[tuple[str, float]] = []
+        all_items = sales_logic.get_items_for_sales_document(sales_document_id)
+        for item in all_items:
+            remaining_qty = item.quantity - item.shipped_quantity
+            if remaining_qty > 0:
+                description = item.product_description
+                if item.product_id:
+                    prod = sales_logic.product_repo.get_product_details(item.product_id)
+                    if prod and prod.get("name"):
+                        description = prod["name"]
+                outstanding_items.append((description, remaining_qty))
+
         pdf = PDF(
             document_number=shipment_number,
             company_name=company_name_for_header,
@@ -144,6 +156,22 @@ def generate_packing_slip_pdf(
                 pdf.cell(qty_col, line_height, f"{qty:.2f}", 1, 1, "R")
         else:
             pdf.cell(col_width_full, line_height, "No items in this shipment.", 1, 1, "C")
+
+        pdf.ln(line_height * 1.5)
+
+        pdf.set_font("Arial", "B", 11)
+        pdf.cell(0, line_height, "Items Remaining to Ship", 0, 1, "L")
+        pdf.set_font("Arial", "B", 10)
+        pdf.set_fill_color(220, 220, 220)
+        pdf.cell(desc_col, line_height, "Product/Service Description", 1, 0, "C", 1)
+        pdf.cell(qty_col, line_height, "Qty Remaining", 1, 1, "C", 1)
+        pdf.set_font("Arial", "", 9)
+        if outstanding_items:
+            for desc, qty in outstanding_items:
+                pdf.cell(desc_col, line_height, desc, 1, 0, "L")
+                pdf.cell(qty_col, line_height, f"{qty:.2f}", 1, 1, "R")
+        else:
+            pdf.cell(col_width_full, line_height, "No remaining items to ship.", 1, 1, "C")
 
         pdf.ln(line_height * 1.5)
 

--- a/core/packing_slip_generator.py
+++ b/core/packing_slip_generator.py
@@ -1,0 +1,167 @@
+import os
+import sys
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PROJECT_ROOT = os.path.dirname(SCRIPT_DIR)
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from core.database import DatabaseHandler
+from core.sales_logic import SalesLogic
+from core.address_book_logic import AddressBookLogic
+from shared.structs import SalesDocumentItem, Account, Address
+from shared.utils import sanitize_filename, address_has_type, address_is_primary_for
+from core.pdf_generator import PDF, get_company_pdf_context
+from core.repositories import AddressRepository, AccountRepository
+from core.address_service import AddressService
+from core.company_repository import CompanyRepository
+from core.company_service import CompanyService
+
+
+def generate_packing_slip_pdf(
+    sales_document_id: int,
+    shipments: dict[int, float],
+    shipment_number: str,
+    output_path: str | None = None,
+    db_handler: DatabaseHandler | None = None,
+):
+    """Generate a packing slip PDF for the specified shipment.
+
+    Args:
+        sales_document_id: ID of the sales order.
+        shipments: Mapping of sales document item IDs to shipped quantities.
+        shipment_number: Identifier for this shipment used in the document header.
+        output_path: Optional explicit path for the resulting PDF file.
+    """
+    close_db = False
+    try:
+        if db_handler is None:
+            db_handler = DatabaseHandler()
+            close_db = True
+        sales_logic = SalesLogic(db_handler)
+        address_book_logic = AddressBookLogic(db_handler)
+
+        address_repo = AddressRepository(db_handler)
+        account_repo = AccountRepository(db_handler)
+        address_service = AddressService(address_repo, account_repo)
+        company_repo = CompanyRepository(db_handler)
+        company_service = CompanyService(company_repo, address_service)
+
+        doc = sales_logic.get_sales_document_details(sales_document_id)
+        if not doc:
+            print(f"Error: Sales document with ID {sales_document_id} not found.")
+            return
+
+        (
+            company_name_for_header,
+            _company_phone,
+            company_shipping_address_pdf_lines,
+            _company_remittance_address_pdf_lines,
+            _company_billing_address_pdf_lines,
+        ) = get_company_pdf_context(company_service)
+
+        customer: Account | None = None
+        customer_shipping_address: Address | None = None
+        if doc.customer_id:
+            customer = address_book_logic.get_account_details(doc.customer_id)
+            if customer:
+                for addr in customer.addresses:
+                    if address_is_primary_for(addr, "Shipping"):
+                        customer_shipping_address = addr
+                        break
+                if (
+                    not customer_shipping_address
+                    and any(address_has_type(addr, "Shipping") for addr in customer.addresses)
+                ):
+                    customer_shipping_address = next(
+                        addr for addr in customer.addresses if address_has_type(addr, "Shipping")
+                    )
+
+        shipped_items: list[tuple[str, float]] = []
+        for item_id, qty in shipments.items():
+            item: SalesDocumentItem = sales_logic.get_sales_document_item_details(item_id)
+            if not item:
+                continue
+            description = item.product_description
+            if item.product_id:
+                prod = sales_logic.product_repo.get_product_details(item.product_id)
+                if prod and prod.get("name"):
+                    description = prod["name"]
+            shipped_items.append((description, qty))
+
+        pdf = PDF(
+            document_number=shipment_number,
+            company_name=company_name_for_header,
+            company_billing_address_lines=company_shipping_address_pdf_lines,
+            document_type="Packing Slip",
+        )
+        pdf.alias_nb_pages()
+        pdf.add_page()
+
+        line_height = 7
+        col_width_full = pdf.w - 2 * pdf.l_margin
+
+        pdf.set_font("Arial", "", 11)
+        date_str = f"Date: {doc.created_date.split('T')[0] if doc.created_date else 'N/A'}"
+        pdf.cell(0, line_height, date_str, 0, 1, "R")
+        pdf.ln(line_height * 1.5)
+
+        col_width_half = col_width_full / 2 - 5
+        pdf.set_font("Arial", "B", 11)
+        pdf.cell(col_width_half, line_height, "Ship To:", 0, 1, "L")
+        pdf.set_font("Arial", "", 11)
+        if customer:
+            pdf.cell(col_width_half, line_height, customer.name or "N/A", 0, 1, "L")
+            if customer_shipping_address:
+                pdf.multi_cell(
+                    col_width_half,
+                    line_height,
+                    "\n".join(
+                        filter(
+                            None,
+                            [
+                                customer_shipping_address.street or "",
+                                f"{customer_shipping_address.city or ''}, {customer_shipping_address.state or ''} {customer_shipping_address.zip_code or ''}",
+                                (customer_shipping_address.country or "").strip(),
+                            ],
+                        )
+                    ),
+                    0,
+                    "L",
+                )
+        pdf.ln(line_height)
+
+        pdf.set_font("Arial", "B", 10)
+        desc_col = col_width_full * 0.80
+        qty_col = col_width_full * 0.20
+        pdf.set_fill_color(220, 220, 220)
+        pdf.cell(desc_col, line_height, "Product/Service Description", 1, 0, "C", 1)
+        pdf.cell(qty_col, line_height, "Qty Shipped", 1, 1, "C", 1)
+        pdf.set_font("Arial", "", 9)
+        if shipped_items:
+            for desc, qty in shipped_items:
+                pdf.cell(desc_col, line_height, desc, 1, 0, "L")
+                pdf.cell(qty_col, line_height, f"{qty:.2f}", 1, 1, "R")
+        else:
+            pdf.cell(col_width_full, line_height, "No items in this shipment.", 1, 1, "C")
+
+        pdf.ln(line_height * 1.5)
+
+        if output_path:
+            filename = output_path
+        else:
+            sanitized_doc_number = sanitize_filename(shipment_number)
+            filename = f"PackingSlip_{sanitized_doc_number}.pdf"
+
+        pdf.output(filename, "F")
+        print(f"PDF generated: {filename}")
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+        import traceback
+        traceback.print_exc()
+    finally:
+        if db_handler and close_db:
+            db_handler.close()
+
+
+__all__ = ["generate_packing_slip_pdf"]

--- a/core/sales_logic.py
+++ b/core/sales_logic.py
@@ -580,8 +580,8 @@ class SalesLogic:
                 continue
         return f"{doc_number}.{max_seq + 1:03d}"
 
-    def record_shipment(self, doc_id: int, items: dict[int, float]) -> None:
-        """Record shipment for multiple sales document items."""
+    def record_shipment(self, doc_id: int, items: dict[int, float]) -> str:
+        """Record shipment for multiple sales document items and return the shipment number."""
         if not items:
             raise ValueError("No items provided for shipment.")
 
@@ -620,6 +620,8 @@ class SalesLogic:
             self.sales_repo.update_sales_document(
                 doc_id, {"status": SalesDocumentStatus.SO_FULFILLED.value}
             )
+
+        return shipment_number
 
     def record_item_shipment(self, item_id: int, quantity: float) -> SalesDocumentItem:
         """Record shipment for a single item using multi-item shipment logic."""

--- a/tests/unit/test_sales_logic.py
+++ b/tests/unit/test_sales_logic.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import MagicMock, patch, call
 import datetime
+import os
+import tempfile
 
 # Assuming core.sales_logic and shared.structs are importable
 # Add project root to sys.path if necessary for imports, or configure test runner
@@ -21,7 +23,9 @@ from shared.structs import (
     AccountType,
     Product,
     InventoryTransactionType,
+    Address,
 )
+from core.packing_slip_generator import generate_packing_slip_pdf
 
 class TestSalesLogic(unittest.TestCase):
 
@@ -739,7 +743,10 @@ class TestSalesLogic(unittest.TestCase):
         self.sales_logic.inventory_service.adjust_stock = MagicMock()
         self.sales_logic.inventory_service.inventory_repo.get_stock_level = MagicMock(return_value=10)
 
-        self.sales_logic.record_shipment(doc_id, {item1_id: 2, item2_id: 1})
+        shipment_number = self.sales_logic.record_shipment(
+            doc_id, {item1_id: 2, item2_id: 1}
+        )
+        self.assertEqual(shipment_number, "S00001.001")
 
         expected_calls = [
             call(101, -2, InventoryTransactionType.SALE, reference="S00001.001"),
@@ -850,3 +857,57 @@ class TestSalesLogicWithPricingRules(unittest.TestCase):
         ]
         self.assertEqual(shipments, expected)
         self.sales_logic.sales_repo.get_shipments_for_sales_document.assert_called_once_with(5)
+
+
+class TestPackingSlipGeneration(unittest.TestCase):
+    def setUp(self):
+        self.db = DatabaseHandler(db_name=':memory:')
+        self.sales_logic = SalesLogic(self.db)
+        self.address_book_logic = AddressBookLogic(self.db)
+
+        addr = Address(
+            street="123 Main",
+            city="Town",
+            state="TS",
+            zip_code="12345",
+            country="USA",
+        )
+        addr.address_type = "Shipping"
+        addr.is_primary = True
+        self.customer = Account(
+            name="Cust", account_type=AccountType.CUSTOMER, addresses=[addr]
+        )
+        self.customer = self.address_book_logic.save_account(self.customer)
+
+        self.product = Product(name="Widget", cost=5.0, sale_price=10.0)
+        self.product.product_id = self.address_book_logic.save_product(self.product)
+        self.sales_logic.inventory_service.adjust_stock(
+            self.product.product_id, 5, InventoryTransactionType.ADJUSTMENT
+        )
+
+        self.quote = self.sales_logic.create_quote(
+            customer_id=self.customer.account_id, reference_number="REF1"
+        )
+        self.item = self.sales_logic.add_item_to_sales_document(
+            self.quote.id, self.product.product_id, 2
+        )
+        self.sales_order = self.sales_logic.convert_quote_to_sales_order(
+            self.quote.id
+        )
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_packing_slip_generation(self):
+        shipments = {self.item.id: 1}
+        shipment_number = self.sales_logic.record_shipment(
+            self.sales_order.id, shipments
+        )
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".pdf")
+        tmp.close()
+        generate_packing_slip_pdf(
+            self.sales_order.id, shipments, shipment_number, tmp.name, self.db
+        )
+        self.assertTrue(os.path.exists(tmp.name))
+        self.assertGreater(os.path.getsize(tmp.name), 0)
+        os.unlink(tmp.name)


### PR DESCRIPTION
## Summary
- Introduce `generate_packing_slip_pdf` for creating shipment packing slips without pricing details.
- Add Export and Exit options in `RecordShippingPopup`, preserving state after recording shipments.
- Return shipment numbers from `SalesLogic.record_shipment` for labeling packing slips.
- Cover shipment number returns and packing slip generation with unit tests.

## Testing
- `pytest tests/unit/test_sales_logic.py::TestSalesLogic::test_record_shipment_multiple_items -q`
- `pytest tests/unit/test_sales_logic.py::TestPackingSlipGeneration::test_packing_slip_generation -q`

------
https://chatgpt.com/codex/tasks/task_e_688f52e5f7308331a3963d381e33d318