### PR TITLE
feat: name RFQ PDFs by status

### DIFF
--- a/core/purchase_order_generator.py
+++ b/core/purchase_order_generator.py
@@ -86,11 +86,12 @@ def generate_po_pdf(purchase_document_id: int, output_path: str = None):
         items: list[PurchaseDocumentItem] = purchase_logic.get_items_for_document(doc.id)
 
         # 5. Initialize PDF (pass document number, company name, and billing address for header)
+        document_type = "Request for Quote" if doc.status == PurchaseDocumentStatus.RFQ else "Purchase Order"
         pdf = PDF(
             document_number=doc.document_number,
             company_name=company_name_for_header,
             company_billing_address_lines=company_billing_address_pdf_lines,
-            document_type="Purchase Order"
+            document_type=document_type
         )
         pdf.alias_nb_pages() # For total page numbers
         pdf.add_page()
@@ -263,7 +264,11 @@ def generate_po_pdf(purchase_document_id: int, output_path: str = None):
         # --- End PDF Content Generation ---
 
         # 5. Determine output filename and save
-        filename = output_path or f"purchase_order_{doc.document_number.replace('/', '_')}.pdf" # Sanitize filename
+        if output_path:
+            filename = output_path
+        else:
+            prefix = "RFQ" if doc.status == PurchaseDocumentStatus.RFQ else "PurchaseOrder"
+            filename = f"{prefix}_{doc.document_number.replace('/', '_')}.pdf"
         pdf.output(filename, "F")
         print(f"PDF generated: {filename}")
 

--- a/ui/purchase_documents/purchase_document_popup.py
+++ b/ui/purchase_documents/purchase_document_popup.py
@@ -150,7 +150,10 @@ class PurchaseDocumentPopup(tk.Toplevel):
             # PDF generation module is now part of the 'core' package
             from core.purchase_order_generator import generate_po_pdf as call_generate_po_pdf
 
-            output_filename = f"purchase_order_{self.doc_number_var.get().replace('/', '_')}.pdf"
+            # Determine filename prefix based on document status
+            status_enum = PurchaseDocumentStatus(self.status_var.get())
+            prefix = "RFQ" if status_enum == PurchaseDocumentStatus.RFQ else "PurchaseOrder"
+            output_filename = f"{prefix}_{self.doc_number_var.get().replace('/', '_')}.pdf"
             # Consider using filedialog.asksaveasfilename here for better UX
 
             # Ensure the output directory exists or handle potential errors if it doesn't


### PR DESCRIPTION
## Summary
- use document status to name exported purchase PDFs
- label RFQ exports as "Request for Quote" in PDF header

## Testing
- `pytest tests/integration/test_interactions.py -vv`
- `pytest tests/integration/test_inventory_workflow.py -vv`
- `pytest tests/integration/test_purchase_system.py -vv`
- `pytest tests/integration/test_sales_shipments.py -vv`
- `pytest tests/unit/test_company_info.py -vv`
- `pytest tests/unit/test_company_service.py -vv`
- `pytest tests/unit/test_inventory_migration.py -vv`
- `pytest tests/unit/test_inventory_service.py -vv`
- `pytest tests/unit/test_logic.py -vv`
- `pytest tests/unit/test_product_management.py -vv`
- `pytest tests/unit/test_purchase_logic.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_688f54651b4c8331b450d0fa7a449892