### PR TITLE
Hide packing slip table when nothing remains

### DIFF
--- a/core/packing_slip_generator.py
+++ b/core/packing_slip_generator.py
@@ -157,23 +157,21 @@ def generate_packing_slip_pdf(
         else:
             pdf.cell(col_width_full, line_height, "No items in this shipment.", 1, 1, "C")
 
-        pdf.ln(line_height * 1.5)
-
-        pdf.set_font("Arial", "B", 11)
-        pdf.cell(0, line_height, "Items Remaining to Ship", 0, 1, "L")
-        pdf.set_font("Arial", "B", 10)
-        pdf.set_fill_color(220, 220, 220)
-        pdf.cell(desc_col, line_height, "Product/Service Description", 1, 0, "C", 1)
-        pdf.cell(qty_col, line_height, "Qty Remaining", 1, 1, "C", 1)
-        pdf.set_font("Arial", "", 9)
         if outstanding_items:
+            pdf.ln(line_height * 1.5)
+
+            pdf.set_font("Arial", "B", 11)
+            pdf.cell(0, line_height, "Items Remaining to Ship", 0, 1, "L")
+            pdf.set_font("Arial", "B", 10)
+            pdf.set_fill_color(220, 220, 220)
+            pdf.cell(desc_col, line_height, "Product/Service Description", 1, 0, "C", 1)
+            pdf.cell(qty_col, line_height, "Qty Remaining", 1, 1, "C", 1)
+            pdf.set_font("Arial", "", 9)
             for desc, qty in outstanding_items:
                 pdf.cell(desc_col, line_height, desc, 1, 0, "L")
                 pdf.cell(qty_col, line_height, f"{qty:.2f}", 1, 1, "R")
-        else:
-            pdf.cell(col_width_full, line_height, "No remaining items to ship.", 1, 1, "C")
 
-        pdf.ln(line_height * 1.5)
+            pdf.ln(line_height * 1.5)
 
         if output_path:
             filename = output_path


### PR DESCRIPTION
## Summary
- Render the "Items Remaining to Ship" section only when there are outstanding items
- Add regression test verifying packing slip omits remaining items table when shipment completes all items

## Testing
- `pytest tests/unit/test_sales_logic.py::TestPackingSlipGeneration -q`


------
https://chatgpt.com/codex/tasks/task_e_688fb30ca96c83318601d149189286de