### PR TITLE
Add account document storage support

### DIFF
--- a/core/address_book_logic.py
+++ b/core/address_book_logic.py
@@ -1,7 +1,10 @@
 from shared.structs import Address, Account, Contact, Product, AccountType, PricingRule, PaymentTerm
+from shared import AccountDocument
 from typing import Optional, List, TYPE_CHECKING
 from enum import Enum
 import logging
+import datetime
+import os
 from core.database import DatabaseHandler
 from core.repositories import (
     AddressRepository,
@@ -178,6 +181,57 @@ class AddressBookLogic:
     def delete_account(self, account_id):
         """Delete an account and its associated contacts."""
         self.account_repo.delete_account(account_id)
+
+    # Account Document Methods
+    def save_account_document(self, document: AccountDocument) -> AccountDocument:
+        """Save a document linked to an account and return the stored object."""
+        if document.account_id is None:
+            raise ValueError("account_id is required to save a document")
+
+        doc_id = self.account_repo.add_account_document(
+            document.account_id,
+            document.document_type,
+            document.file_path,
+            document.uploaded_at.isoformat() if document.uploaded_at else None,
+            document.expires_at.isoformat() if document.expires_at else None,
+        )
+        document.document_id = doc_id
+        return document
+
+    def get_account_documents(self, account_id: int) -> List[AccountDocument]:
+        """Retrieve all documents associated with an account."""
+        docs = []
+        for row in self.account_repo.get_account_documents(account_id):
+            uploaded_at = row["uploaded_at"]
+            if isinstance(uploaded_at, str):
+                uploaded_at = datetime.datetime.fromisoformat(uploaded_at)
+            expires_at = row["expires_at"]
+            if isinstance(expires_at, str):
+                expires_at = datetime.datetime.fromisoformat(expires_at)
+
+            docs.append(
+                AccountDocument(
+                    document_id=row["document_id"],
+                    account_id=row["account_id"],
+                    document_type=row["document_type"],
+                    file_path=row["file_path"],
+                    uploaded_at=uploaded_at,
+                    expires_at=expires_at,
+                )
+            )
+        return docs
+
+    def delete_account_document(self, document: AccountDocument) -> None:
+        """Delete the provided account document."""
+        if document.document_id is None:
+            raise ValueError("Document ID is required for deletion")
+        self.account_repo.delete_account_document(document.document_id)
+        if document.file_path and self.account_repo.count_account_documents_by_path(document.file_path) == 0:
+            try:
+                if os.path.exists(document.file_path):
+                    os.remove(document.file_path)
+            except OSError:
+                logger.warning("Failed to remove file %s", document.file_path)
 
 #Contacts Methods
     def get_contact_details(self, contact_id: int) -> Contact | None:

--- a/core/database_setup.py
+++ b/core/database_setup.py
@@ -41,6 +41,20 @@ def create_tables(db_conn=None):
             company,
         ):
             module.create_schema(cursor)
+        # Ensure account_documents table exists for storing documents linked to accounts
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS account_documents (
+                document_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                account_id INTEGER NOT NULL,
+                document_type TEXT NOT NULL,
+                file_path TEXT NOT NULL,
+                uploaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                expires_at TIMESTAMP,
+                FOREIGN KEY (account_id) REFERENCES accounts (id) ON DELETE CASCADE
+            )
+            """
+        )
         versioning.ensure_version_table(cursor, versioning.SCHEMA_VERSION)
         conn.commit()
         print("Database tables created successfully (if they didn't exist).")

--- a/core/preferences.py
+++ b/core/preferences.py
@@ -11,6 +11,7 @@ PREFERENCES_FILE = Path(__file__).resolve().parent.parent / 'preferences.json'
 DEFAULT_PREFERENCES: Dict[str, Any] = {
     'require_reference_on_quote_accept': False,
     'default_quote_expiry_days': 30,
+    'document_storage_path': 'uploaded_documents',
 }
 
 def load_preferences() -> Dict[str, Any]:

--- a/core/repositories.py
+++ b/core/repositories.py
@@ -103,6 +103,19 @@ class AccountRepository:
     def remove_payment_term_from_account(self, account_id):
         self.db.remove_payment_term_from_account(account_id)
 
+    # Account documents
+    def add_account_document(self, account_id, document_type, file_path, uploaded_at=None, expires_at=None):
+        return self.db.add_account_document(account_id, document_type, file_path, uploaded_at, expires_at)
+
+    def get_account_documents(self, account_id):
+        return self.db.get_account_documents(account_id)
+
+    def delete_account_document(self, document_id):
+        self.db.delete_account_document(document_id)
+
+    def count_account_documents_by_path(self, file_path):
+        return self.db.count_account_documents_by_path(file_path)
+
 
 class ProductRepository:
     """Repository for product-related operations."""

--- a/core/schema/accounts.py
+++ b/core/schema/accounts.py
@@ -63,3 +63,15 @@ def create_schema(cursor: sqlite3.Cursor) -> None:
             UPDATE contacts SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id;
         END;
     """)
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS account_documents (
+            document_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            account_id INTEGER NOT NULL,
+            document_type TEXT NOT NULL,
+            file_path TEXT NOT NULL,
+            uploaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            expires_at TIMESTAMP,
+            FOREIGN KEY (account_id) REFERENCES accounts (id) ON DELETE CASCADE
+        )
+    """)

--- a/preferences.json
+++ b/preferences.json
@@ -1,4 +1,5 @@
 {
   "require_reference_on_quote_accept": false,
-  "default_quote_expiry_days": 30
+  "default_quote_expiry_days": 30,
+  "document_storage_path": "uploaded_documents"
 }

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -3,10 +3,12 @@
 from .account_structs import AccountType, Address, Account, Contact
 from .interaction_structs import InteractionType, Interaction
 from .task_structs import TaskStatus, TaskPriority, Task
+from .document_structs import AccountDocument
 from .structs import *  # Re-export remaining legacy structures
 
 __all__ = [
     "AccountType", "Address", "Account", "Contact",
     "InteractionType", "Interaction",
     "TaskStatus", "TaskPriority", "Task",
+    "AccountDocument",
 ]

--- a/shared/document_structs.py
+++ b/shared/document_structs.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+from typing import Optional
+import datetime
+
+@dataclass
+class AccountDocument:
+    document_id: Optional[int] = None
+    account_id: Optional[int] = None
+    document_type: str = ""
+    file_path: str = ""
+    uploaded_at: Optional[datetime.datetime] = None
+    expires_at: Optional[datetime.datetime] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "document_id": self.document_id,
+            "account_id": self.account_id,
+            "document_type": self.document_type,
+            "file_path": self.file_path,
+            "uploaded_at": self.uploaded_at.isoformat() if self.uploaded_at else None,
+            "expires_at": self.expires_at.isoformat() if self.expires_at else None,
+        }
+
+    def __str__(self) -> str:
+        return (
+            f"Document ID: {self.document_id}\n"
+            f"Account ID: {self.account_id}\n"
+            f"Type: {self.document_type}\n"
+            f"File Path: {self.file_path}\n"
+            f"Uploaded At: {self.uploaded_at.isoformat() if self.uploaded_at else 'N/A'}\n"
+            f"Expires At: {self.expires_at.isoformat() if self.expires_at else 'N/A'}"
+        )
+

--- a/tests/integration/test_account_document_integration.py
+++ b/tests/integration/test_account_document_integration.py
@@ -1,0 +1,60 @@
+import unittest
+import os
+import tempfile
+import shutil
+import datetime
+from core.database import DatabaseHandler
+from core.address_book_logic import AddressBookLogic
+from shared import Account, AccountType, AccountDocument
+
+class TestAccountDocumentIntegration(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.db_name = "test_account_documents_integration.db"
+        if os.path.exists(cls.db_name):
+            os.remove(cls.db_name)
+        cls.db = DatabaseHandler(db_name=cls.db_name)
+        cls.logic = AddressBookLogic(cls.db)
+        account = Account(name="Vendor Int", account_type=AccountType.VENDOR)
+        saved = cls.logic.save_account(account)
+        cls.account_id = saved.account_id
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.db.close()
+        if os.path.exists(cls.db_name):
+            os.remove(cls.db_name)
+
+    def test_upload_retrieve_delete_document(self):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            src = os.path.join(tmpdir, "src.txt")
+            with open(src, "w", encoding="utf-8") as fh:
+                fh.write("data")
+
+            storage_dir = os.path.join(tmpdir, "storage")
+            os.makedirs(storage_dir, exist_ok=True)
+            stored = os.path.join(storage_dir, "stored.txt")
+            shutil.copy(src, stored)
+
+            doc = AccountDocument(
+                account_id=self.account_id,
+                document_type="License",
+                file_path=stored,
+                uploaded_at=datetime.datetime.now(),
+            )
+            saved = self.logic.save_account_document(doc)
+            self.assertIsNotNone(saved.document_id)
+
+            docs = self.logic.get_account_documents(self.account_id)
+            self.assertEqual(len(docs), 1)
+            self.assertEqual(docs[0].file_path, stored)
+
+            self.logic.delete_account_document(saved)
+            self.assertFalse(os.path.exists(stored))
+            self.assertEqual(self.logic.get_account_documents(self.account_id), [])
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/manual/account_documents_ui.md
+++ b/tests/manual/account_documents_ui.md
@@ -1,0 +1,8 @@
+# Account Documents UI Manual Test
+
+1. Launch the application with `python main.py`.
+2. Navigate to the Accounts tab and open an existing vendor or create a new one.
+3. In the account details popup, locate the **Documents** section.
+4. Click **Upload** and choose a file from your system. Confirm it appears in the list with the correct type and filename.
+5. Select the document and click **Open** to verify it opens with the default viewer.
+6. Select the document and click **Delete**. Ensure it disappears from the list and the file is removed from the storage directory (default `uploaded_documents`).

--- a/tests/unit/test_account_document_logic.py
+++ b/tests/unit/test_account_document_logic.py
@@ -1,0 +1,53 @@
+import unittest
+import tempfile
+import os
+import datetime
+from core.database import DatabaseHandler
+from core.address_book_logic import AddressBookLogic
+from shared import Account, AccountType, AccountDocument
+
+class TestAccountDocumentLogic(unittest.TestCase):
+    def setUp(self):
+        self.db = DatabaseHandler(db_name=':memory:')
+        self.logic = AddressBookLogic(self.db)
+        account = Account(name="Vendor", account_type=AccountType.VENDOR)
+        saved = self.logic.save_account(account)
+        self.account_id = saved.account_id
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_save_get_delete_document(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, "doc.txt")
+            with open(file_path, "w", encoding="utf-8") as fh:
+                fh.write("content")
+
+            doc1 = AccountDocument(
+                account_id=self.account_id,
+                document_type="License",
+                file_path=file_path,
+                uploaded_at=datetime.datetime.now(),
+            )
+            saved1 = self.logic.save_account_document(doc1)
+            self.assertIsNotNone(saved1.document_id)
+
+            doc2 = AccountDocument(
+                account_id=self.account_id,
+                document_type="Contract",
+                file_path=file_path,
+                uploaded_at=datetime.datetime.now(),
+            )
+            saved2 = self.logic.save_account_document(doc2)
+
+            docs = self.logic.get_account_documents(self.account_id)
+            self.assertEqual(len(docs), 2)
+
+            self.logic.delete_account_document(saved1)
+            self.assertTrue(os.path.exists(file_path))
+
+            self.logic.delete_account_document(saved2)
+            self.assertFalse(os.path.exists(file_path))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_account_document_repository.py
+++ b/tests/unit/test_account_document_repository.py
@@ -1,0 +1,41 @@
+import unittest
+from core.database import DatabaseHandler
+from core.repositories import AccountRepository
+from shared import AccountType
+
+class TestAccountDocumentRepository(unittest.TestCase):
+    def setUp(self):
+        self.db = DatabaseHandler(db_name=':memory:')
+        self.repo = AccountRepository(self.db)
+        self.account_id = self.repo.add_account(
+            name="Vendor A",
+            phone="123",
+            website="",
+            description="",
+            account_type=AccountType.VENDOR.value,
+        )
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_add_get_delete_and_count_documents(self):
+        path = "testfile.txt"
+        doc1_id = self.repo.add_account_document(self.account_id, "License", path)
+        doc2_id = self.repo.add_account_document(self.account_id, "Contract", path)
+
+        docs = self.repo.get_account_documents(self.account_id)
+        self.assertEqual(len(docs), 2)
+        self.assertEqual(self.repo.count_account_documents_by_path(path), 2)
+
+        self.repo.delete_account_document(doc1_id)
+        self.assertEqual(self.repo.count_account_documents_by_path(path), 1)
+        docs_after = self.repo.get_account_documents(self.account_id)
+        self.assertEqual(len(docs_after), 1)
+
+        self.repo.delete_account_document(doc2_id)
+        self.assertEqual(self.repo.count_account_documents_by_path(path), 0)
+        docs_final = self.repo.get_account_documents(self.account_id)
+        self.assertEqual(docs_final, [])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- create `account_documents` table for storing account file metadata
- ensure database setup initializes new table
- add repository and database methods to manage account documents
- expose `AccountDocument` dataclass for shared use
- provide logic helpers to save, fetch, and delete account documents
- integrate document management UI into account popup with upload/open/delete actions
- add configurable storage path for uploaded documents and clean up unreferenced files
- handle datetime values when mapping account documents
- add unit/integration tests and manual UI steps for account document workflows

## Testing
- `python -m pytest tests/unit/test_account_document_repository.py tests/unit/test_account_document_logic.py tests/integration/test_account_document_integration.py -vv`
- `python -m pytest tests/unit/test_company_info.py -vv`
- `python -m pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'Xvfb')*


------
https://chatgpt.com/codex/tasks/task_e_68937cb9973c8331854445f24d4d49e1