### PR TITLE
Redirect print statements to centralized logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ Thumbs.db
 
 # Generated documents
 *.pdf
+logs/

--- a/main.py
+++ b/main.py
@@ -2,8 +2,12 @@ import tkinter as tk
 from ui.main_view import AddressBookView
 from core.address_book_logic import AddressBookLogic
 from core.database import DatabaseHandler
+from shared.logging_config import setup_logging
 
 if __name__ == '__main__':
+    # Configure logging and redirect prints before any application logic runs
+    setup_logging()
+
     # Initialize database and logic
     # The DatabaseHandler path for the DB file will be fixed in a later step.
     db_handler = DatabaseHandler()

--- a/scripts/migrate_inventory.py
+++ b/scripts/migrate_inventory.py
@@ -1,6 +1,7 @@
 """One-time migration to add inventory columns to products and backfill quantities."""
 import sqlite3
 from core.database_setup import DB_NAME
+from shared.logging_config import setup_logging
 
 def column_exists(cursor, table, column):
     cursor.execute(f"PRAGMA table_info({table})")
@@ -32,4 +33,5 @@ def run_migration(db_path=DB_NAME):
         conn.close()
 
 if __name__ == "__main__":
+    setup_logging()
     run_migration()

--- a/scripts/sandbox_data.py
+++ b/scripts/sandbox_data.py
@@ -7,6 +7,7 @@ application has meaningful data to interact with.
 
 import os
 import sys
+from shared.logging_config import setup_logging
 
 # Ensure project root is on the path for absolute imports
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -270,6 +271,7 @@ def populate_data() -> None:
 
 
 if __name__ == "__main__":
+    setup_logging()
     db_path = os.path.join(PROJECT_ROOT, "core", "address_book.db")
     if os.path.exists(db_path):
         print(f"Deleting existing database file: {db_path}")

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -13,7 +13,7 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 project_root = os.path.dirname(current_dir)
 sys.path.insert(0, project_root)
 
-
+from shared.logging_config import setup_logging
 def build_dependencies():
     """
     Placeholder for any build steps or dependency checks.
@@ -58,6 +58,7 @@ def run_tests():
         return 1
 
 if __name__ == '__main__':
+    setup_logging()
     build_dependencies()
     exit_code = run_tests()
     sys.exit(exit_code)

--- a/shared/logging_config.py
+++ b/shared/logging_config.py
@@ -1,0 +1,30 @@
+import logging
+from pathlib import Path
+import builtins
+
+def setup_logging(log_dir: str = "logs", filename: str = "app.log", level: int = logging.INFO) -> logging.Logger:
+    """Configure root logger to write to a file in *log_dir* and override ``print``.
+
+    The directory is created if it does not exist.  All calls to ``print`` after
+    this function runs will be redirected to the logger at INFO level so that
+    existing debugging statements are preserved in the log file.
+    """
+    log_path = Path(log_dir)
+    log_path.mkdir(parents=True, exist_ok=True)
+    log_file = log_path / filename
+
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        handlers=[
+            logging.FileHandler(log_file),
+            logging.StreamHandler()
+        ]
+    )
+
+    def log_print(*args, **kwargs):
+        message = " ".join(str(arg) for arg in args)
+        logging.getLogger().info(message)
+
+    builtins.print = log_print
+    return logging.getLogger()


### PR DESCRIPTION
## Summary
- Introduce shared logging configuration that writes to `logs/app.log` and replaces `print` with `logging`
- Initialize central logging in application entrypoint and scripts
- Ignore generated `logs/` directory

## Testing
- `python scripts/test.py` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'Xvfb')*


------
https://chatgpt.com/codex/tasks/task_e_6898e6c0640483319f60a12360fa3533