### PR TITLE
Add database migration framework

### DIFF
--- a/core/schema/versioning.py
+++ b/core/schema/versioning.py
@@ -1,9 +1,21 @@
 import sqlite3
+from typing import Callable, Dict
 
-SCHEMA_VERSION = 1
 
-def ensure_version_table(cursor: sqlite3.Cursor, version: int) -> None:
-    """Ensure the schema_version table exists and is set to the given version."""
+# The current schema version of the application.  Increment this whenever a
+# backwards compatible migration is added below.
+SCHEMA_VERSION = 2
+
+
+def ensure_version_table(cursor: sqlite3.Cursor) -> None:
+    """Ensure that the ``schema_version`` table exists.
+
+    The table keeps a history of schema migrations that have been applied to the
+    database.  We do **not** insert a row for the current version here because
+    that is handled by :func:`apply_migrations` after any required migrations are
+    executed.
+    """
+
     cursor.execute(
         """
         CREATE TABLE IF NOT EXISTS schema_version (
@@ -12,9 +24,76 @@ def ensure_version_table(cursor: sqlite3.Cursor, version: int) -> None:
         )
         """
     )
-    cursor.execute("SELECT version FROM schema_version ORDER BY version DESC LIMIT 1")
+
+
+def get_current_version(cursor: sqlite3.Cursor) -> int:
+    """Return the most recently applied schema version.
+
+    If the table is empty (i.e. a brand new database) we consider the version to
+    be ``0``.
+    """
+
+    cursor.execute("SELECT MAX(version) FROM schema_version")
     row = cursor.fetchone()
-    if row is None:
+    return row[0] if row and row[0] is not None else 0
+
+
+def _column_exists(cursor: sqlite3.Cursor, table: str, column: str) -> bool:
+    cursor.execute(f"PRAGMA table_info({table})")
+    return any(row[1] == column for row in cursor.fetchall())
+
+
+def _add_column_if_missing(cursor: sqlite3.Cursor, table: str, column: str, definition: str) -> None:
+    if not _column_exists(cursor, table, column):
+        cursor.execute(f"ALTER TABLE {table} ADD COLUMN {column} {definition}")
+
+
+def _migrate_to_2(cursor: sqlite3.Cursor) -> None:
+    """Migration to schema version 2.
+
+    Version 2 introduces inventory tracking fields on the ``products`` table. If
+    these columns are missing we add them and backfill the
+    ``quantity_on_hand`` value from the existing ``product_inventory`` table.
+    """
+
+    _add_column_if_missing(cursor, "products", "quantity_on_hand", "REAL NOT NULL DEFAULT 0")
+    _add_column_if_missing(cursor, "products", "reorder_point", "REAL NOT NULL DEFAULT 0")
+    _add_column_if_missing(cursor, "products", "reorder_quantity", "REAL NOT NULL DEFAULT 0")
+    _add_column_if_missing(cursor, "products", "safety_stock", "REAL NOT NULL DEFAULT 0")
+
+    cursor.execute(
+        """
+        UPDATE products
+        SET quantity_on_hand = (
+            SELECT IFNULL(SUM(quantity), 0)
+            FROM product_inventory
+            WHERE product_id = products.id
+        )
+        """
+    )
+
+
+# Mapping of schema version -> migration function.  Each migration upgrades the
+# database *from* the previous version *to* the specified version.
+MIGRATIONS: Dict[int, Callable[[sqlite3.Cursor], None]] = {
+    2: _migrate_to_2,
+}
+
+
+def apply_migrations(cursor: sqlite3.Cursor, target_version: int = SCHEMA_VERSION) -> None:
+    """Apply any outstanding migrations up to ``target_version``.
+
+    This function is idempotent – running it multiple times will have no effect
+    once the database has reached ``target_version``.
+    """
+
+    ensure_version_table(cursor)
+    current_version = get_current_version(cursor)
+
+    for version in range(current_version + 1, target_version + 1):
+        migration = MIGRATIONS.get(version)
+        if migration:
+            migration(cursor)
+        # Record that the migration has been applied.  We keep a history of
+        # versions so a simple INSERT suffices.
         cursor.execute("INSERT INTO schema_version (version) VALUES (?)", (version,))
-    elif row[0] != version:
-        cursor.execute("UPDATE schema_version SET version = ?, applied_at = CURRENT_TIMESTAMP", (version,))

--- a/tests/unit/test_schema_versioning.py
+++ b/tests/unit/test_schema_versioning.py
@@ -1,0 +1,65 @@
+import os
+import sqlite3
+import tempfile
+
+from core.database_setup import initialize_database
+from core.schema import versioning
+
+
+def test_initialize_database_applies_migrations():
+    """Existing databases are upgraded in place without data loss."""
+
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    try:
+        # Create a database that mimics an old schema version (v1)
+        conn = sqlite3.connect(path)
+        cur = conn.cursor()
+        cur.execute(
+            "CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)"
+        )
+        cur.execute("INSERT INTO schema_version (version) VALUES (1)")
+        # Simulate a simplified version of the original products table prior to
+        # version 2.  It lacks the inventory related columns that the migration
+        # will add but includes an ``updated_at`` column so that triggers created
+        # during table initialisation function correctly.
+        cur.execute(
+            "CREATE TABLE products (id INTEGER PRIMARY KEY AUTOINCREMENT, sku TEXT, name TEXT, updated_at DATETIME)"
+        )
+        cur.execute("INSERT INTO products (sku, name) VALUES ('P1', 'Prod')")
+        cur.execute(
+            "CREATE TABLE product_inventory (id INTEGER PRIMARY KEY AUTOINCREMENT, product_id INTEGER, location_id INTEGER, quantity REAL)"
+        )
+        cur.execute(
+            "INSERT INTO product_inventory (product_id, location_id, quantity) VALUES (1,1,7)"
+        )
+        conn.commit()
+        conn.close()
+
+        # Run initialization which should apply migrations and preserve data
+        conn = sqlite3.connect(path)
+        initialize_database(db_conn=conn)
+
+        cur = conn.cursor()
+        cur.execute("PRAGMA table_info(products)")
+        cols = {row[1] for row in cur.fetchall()}
+        assert {
+            "quantity_on_hand",
+            "reorder_point",
+            "reorder_quantity",
+            "safety_stock",
+        }.issubset(cols)
+
+        cur.execute(
+            "SELECT quantity_on_hand, reorder_point, reorder_quantity, safety_stock FROM products WHERE id=1"
+        )
+        qoh, rp, rq, ss = cur.fetchone()
+        assert qoh == 7
+        assert rp == 0 and rq == 0 and ss == 0
+
+        cur.execute("SELECT MAX(version) FROM schema_version")
+        assert cur.fetchone()[0] == versioning.SCHEMA_VERSION
+        conn.close()
+    finally:
+        os.remove(path)
+


### PR DESCRIPTION
## Summary
- introduce versioned migration system with automatic schema upgrades
- run migrations during database initialization to preserve existing data
- add test covering upgrade from legacy database

## Testing
- `pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'Xvfb')*
- `pytest tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_689bd7cc15548331993c2b7284af5fdf